### PR TITLE
Move URI unit tests to GTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/tools)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uri/datamodel)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uri/serializer)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uri/validator)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uuid)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uuid/factory)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/uprotocol/uuid/serializer)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/uprotocol-core-api/src/main/proto)
 include_directories(${CGREEN_INCLUDE_DIR})
 
@@ -78,11 +79,11 @@ file(GLOB SRC_HDR_JSON 	 			 "uprotocol/serialize/*.h")
 file(GLOB SRC_HDR_MODEL  			 "uprotocol/cloudevent/datamodel/*.h")
 file(GLOB SRC_HDR_FACTORY 			 "uprotocol/cloudevent/factory/*.h")
 file(GLOB SRC_HDR_URI 				 "uprotocol/uri/**/*.h")
-file(GLOB SRC_HDR_UUID 				 "uprotocol/uuid/*.h")
+file(GLOB SRC_HDR_UUID 				 "uprotocol/uuid/**/*.h")
 file(GLOB SRC_HDR_TOOLS 			 "uprotocol/uuid/tools/*.h")
 file(GLOB_RECURSE SRC_PROTO_CORE_API "${CMAKE_CURRENT_BINARY_DIR}/uprotocol-core-api/src/main/proto/*.cc")
 
-set(uprotocol_src 
+set(uprotocol_src
 	src/base64/base64.cpp
 	src/uuid/Uuidv8Factory.cpp
 	src/uuid/UuidSerializer.cpp
@@ -108,15 +109,15 @@ add_library(uprotocolsdk STATIC $<TARGET_OBJECTS:uprotocollib>)
 
 add_definitions(-DSPDLOG_FMT_EXTERNAL)
 
-target_link_libraries(uprotocolsdk 
-                      Threads::Threads 
-					  ${Protobuf_LIBRARIES} 
-					  ${RapidJSON_LIBRARIES} 
+target_link_libraries(uprotocolsdk
+                      Threads::Threads
+					  ${Protobuf_LIBRARIES}
+					  ${RapidJSON_LIBRARIES}
 					  ${UUID_LIBRARY}
 					  proto
 					  spdlog::spdlog)
 
-target_link_libraries(uprotocolsdk_shared 
+target_link_libraries(uprotocolsdk_shared
 					  Threads::Threads
 					  ${Protobuf_LIBRARIES}
 					  ${RapidJSON_LIBRARIES}
@@ -149,7 +150,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 			target_compile_options(uprotocolsdk PRIVATE -Wall -Wextra -Werror)
 			target_compile_options(uprotocolsdk_shared PRIVATE -Wall -Wextra -Werror)
 		endif()
-endif()					  
+endif()
 
 include(ExternalProject)
 
@@ -157,7 +158,7 @@ ExternalProject_Add(
 	uprotocol-core-api
 	PREFIX uprotocol-core-api-prefix
 	SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../uprotocol-core-api"
-	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/uprotocol-core-api" 
+	BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/uprotocol-core-api"
 	INSTALL_COMMAND "" # No install step if not needed
 )
 

--- a/src/uri/IpAddress.cpp
+++ b/src/uri/IpAddress.cpp
@@ -56,14 +56,11 @@ void IpAddress::toBytes() {
  */
 void IpAddress::toString() {
     if (!ipBytes_.empty()) {
-        
-        ipString_.reserve(INET6_ADDRSTRLEN + 1);
-
-        auto inetType = (type_ == AddressType::IpV4) ? AF_INET : AF_INET6;
-
-        if (inet_ntop(inetType, &ipBytes_[0], ipString_.data(), INET6_ADDRSTRLEN) == nullptr) {
-            spdlog::error("inet_ntop failed");
-        }
+	    auto inetType = (type_ == AddressType::IpV4) ? AF_INET : AF_INET6;
+	    if (std::string ipString(INET6_ADDRSTRLEN, '\0');
+	        inet_ntop(inetType, &ipBytes_[0], ipString.data(), INET6_ADDRSTRLEN) != nullptr) {
+    		ipString_ = ipString.data();
+	    }
     } else {
         spdlog::error("ipBytes is empty");
     }

--- a/src/uri/LongUriSerializer.cpp
+++ b/src/uri/LongUriSerializer.cpp
@@ -198,6 +198,7 @@ UEntity LongUriSerializer::parseUEntity(std::string_view entity, std::string_vie
         entityVersion = std::optional<uint8_t>(std::strtol(version.data(), &endptr, 10));
         if (*endptr != '\0') {
             spdlog::error("Invalid conversion for version");
+            entityVersion = std::nullopt;	     
         }
     }
    

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,4 @@
 set(TESTS_PATH ../test)
-
- #Add gtest  files
-    #set(gtest_libs gtest_main)
-#    find_library(gtest_main libgtest_main)
- #   add_library(gtest_main SHARED IMPORTED)
-  #  set_property(TARGET gtest_main PROPERTY IMPORTED_LOCATION ${gtest_main})
-   # message("${this_lib}/CMakeLists.txt : Linking google test libraries...")
-
 set(GTEST_LIB gtest)
 ## setting the compiler
 include_directories(../proto)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TESTS_PATH ../test)
 set(GTEST_LIB gtest)
 ## setting the compiler
 include_directories(../proto)
+
 add_executable(json_serializer_test
 		${TESTS_PATH}/json/json_serializer_test.cpp
 		${CGREEN_INCLUDE_DIR}
@@ -39,60 +40,74 @@ add_executable(attribute_tests
 target_link_libraries(attribute_tests ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-03-attribute-test" attribute_tests)
 
-#add_executable(uuid_v8_tests
-#	${TESTS_PATH}/uuid/uuid_v8_test.cpp ${SRC_HDR_UUID})
-
-#target_link_libraries(uuid_v8_tests ${CGREEN_LIBRARY} uprotocolsdk)
-#add_test("t-04-uuid-v8" uuid_v8_tests)
-
-#add_executable(uuid_gen_test
-#	${TESTS_PATH}/uuid/uuid_gen_test.cpp)
-#target_link_libraries(uuid_gen_test ${CGREEN_LIBRARY} uprotocolsdk)
-#add_test("t-05-uuid-gen-test" uuid_gen_test)
-
+add_executable(uuid_test
+	${TESTS_PATH}/uuid/uuid_test.cpp)
+target_link_libraries(uuid_test ${GTEST_LIB} uprotocolsdk)
+add_test("t-04-uuid-test" uuid_test)
 
 add_executable(base64_test ${TESTS_PATH}/tools/base64_test.cpp)
-
 target_link_libraries(base64_test ${OPENSSL_LIBRARIES} ${CGREEN_LIBRARY} uprotocolsdk)
+add_test("t-05-base64-test" base64_test)
 
-add_test("t-06-base64-test" base64_test)
-
-
-
-add_test("t-07-ce-factory-test" base64_test)
+add_test("t-06-ce-factory-test" base64_test)
 add_executable(service_type_test ${TESTS_PATH}/model/serviceType_test.cpp)
 target_link_libraries(service_type_test ${CGREEN_LIBRARY} uprotocolsdk)
 
-add_test("t-08-service-type-test" service_type_test)
+add_test("t-07-service-type-test" service_type_test)
 
 add_executable(UAuthorityTest
 	${TESTS_PATH}/uri/datamodel/UAuthorityTest.cpp)
 target_link_libraries(UAuthorityTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-09-UAuthorityTest" UAuthorityTest)
+add_test("t-08-UAuthorityTest" UAuthorityTest)
 
 add_executable(UEntityTest
 		${TESTS_PATH}/uri/datamodel/UEntityTest.cpp)
 target_link_libraries(UEntityTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-10-UEntityTest" UEntityTest)
+add_test("t-9-UEntityTest" UEntityTest)
 
 add_executable(UResourceTest
 	${TESTS_PATH}/uri/datamodel/UResourceTest.cpp)
 target_link_libraries(UResourceTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-11-UResourceTest" UResourceTest)
+add_test("t-10-UResourceTest" UResourceTest)
 
 add_executable(UUriTest
 	${TESTS_PATH}/uri/datamodel/UUriTest.cpp)
 target_link_libraries(UUriTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-12-UUriTest" UUriTest)
+add_test("t-11-UUriTest" UUriTest)
 
 add_executable(LongUriSerializerTest
 	${TESTS_PATH}/uri/serializer/LongUriSerializerTest.cpp)
 target_compile_options(LongUriSerializerTest PRIVATE -g -O0)
 target_link_libraries(LongUriSerializerTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-13-LongUriSerializerTest"  LongUriSerializerTest)
+add_test("t-12-LongUriSerializerTest"  LongUriSerializerTest)
 
 add_executable(MicroUriSerializerTest
 	${TESTS_PATH}/uri/serializer/MicroUriSerializerTest.cpp)
 target_compile_options(MicroUriSerializerTest PRIVATE -g -O0)
 target_link_libraries(MicroUriSerializerTest ${GTEST_LIB} uprotocolsdk)
-add_test("t-14-MicroUriSerializerTest"  MicroUriSerializerTest)
+add_test("t-13-MicroUriSerializerTest"  MicroUriSerializerTest)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+add_executable(uattributes_test
+	${TESTS_PATH}/utransport/uattributes_test.cpp)
+target_link_libraries(uattributes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+add_executable(umessagetypes_test
+	${TESTS_PATH}/utransport/umessagetypes_test.cpp)
+target_link_libraries(umessagetypes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+add_executable(upayload_test
+	${TESTS_PATH}/utransport/upayload_test.cpp)
+target_link_libraries(upayload_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+add_executable(upriority_test
+	${TESTS_PATH}/utransport/upriority_test.cpp)
+target_link_libraries(upriority_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
+add_executable(userializationhint_test
+	${TESTS_PATH}/utransport/userializationhint_test.cpp)
+target_link_libraries(userializationhint_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,23 @@
 set(TESTS_PATH ../test)
 
-include_directories(../uprotocol/proto)
+ #Add gtest  files
+    #set(gtest_libs gtest_main)
+#    find_library(gtest_main libgtest_main)
+ #   add_library(gtest_main SHARED IMPORTED)
+  #  set_property(TARGET gtest_main PROPERTY IMPORTED_LOCATION ${gtest_main})
+   # message("${this_lib}/CMakeLists.txt : Linking google test libraries...")
 
-file(GLOB_RECURSE SRC_PROTO_CORE_API "${CMAKE_CURRENT_BINARY_DIR}/uprotocol-core-api/src/main/proto/*.cc")
-
-
+set(GTEST_LIB gtest)
+## setting the compiler
+include_directories(../proto)
 add_executable(json_serializer_test
-			   ${TESTS_PATH}/json/json_serializer_test.cpp
-			   ${CGREEN_INCLUDE_DIR}
-			   ${SRC_HDR_MODEL}
-			   ${SRC_HDR_JSON}
-			   ${PROTO_HDR_FILE}
-			   ${PROTO_CPP_FILE})
+		${TESTS_PATH}/json/json_serializer_test.cpp
+		${CGREEN_INCLUDE_DIR}
+		${SRC_HDR_MODEL}
+		${SRC_HDR_JSON}
+		${PROTO_HDR_FILE}
+		${PROTO_CPP_FILE})
 
-add_dependencies(json_serializer_test uprotocol-core-api)
 target_link_libraries(json_serializer_test ${CGREEN_LIBRARY} ${RapidJSON_LIBRARIES} uprotocolsdk)
 
 find_package(Protobuf REQUIRED)
@@ -23,14 +27,13 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 protobuf_generate_cpp(TEST_PROTO_SRCS TEST_PROTO_HDRS ${TESTS_PATH}/factory/test.proto)
 
 add_executable(binary_serializer_test
-				${TESTS_PATH}/binary/binary_test.cpp
-				${SRC_HDR_MODEL}
-				${SRC_HDR_BINARY}
-				${PROTO_HDR_FILE}
-				${PROTO_CPP_FILE}
-				)
+		${TESTS_PATH}/binary/binary_test.cpp
+		${SRC_HDR_MODEL}
+		${SRC_HDR_BINARY}
+		${PROTO_HDR_FILE}
+		${PROTO_CPP_FILE}
+		)
 
-add_dependencies(binary_serializer_test uprotocol-core-api)
 target_link_libraries(binary_serializer_test ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-01-binary-serializer" binary_serializer_test)
 
@@ -40,22 +43,29 @@ target_link_libraries(priority_enum_test ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-02-priority-enum-test" priority_enum_test)
 
 add_executable(attribute_tests
-		${TESTS_PATH}/model/attributes_test.cpp
-		${SRC_PROTO_CORE_API})
+		${TESTS_PATH}/model/attributes_test.cpp)
 target_link_libraries(attribute_tests ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-03-attribute-test" attribute_tests)
 
-add_executable(base64_test 
-	${TESTS_PATH}/tools/base64_test.cpp)
-target_link_libraries(base64_test gtest gtest_main uprotocolsdk)
-add_test("t-06-base64-test" base64_test)	
+#add_executable(uuid_v8_tests
+#	${TESTS_PATH}/uuid/uuid_v8_test.cpp ${SRC_HDR_UUID})
 
-add_executable(ce_factory_test 	${CGREEN_INCLUDE_DIR} ${TEST_PROTO_SRCS} ${TEST_PROTO_HDRS}
-		${TESTS_PATH}/factory/cloud_event_factory_test.cpp)
+#target_link_libraries(uuid_v8_tests ${CGREEN_LIBRARY} uprotocolsdk)
+#add_test("t-04-uuid-v8" uuid_v8_tests)
 
-add_dependencies(ce_factory_test uprotocol-core-api)
+#add_executable(uuid_gen_test
+#	${TESTS_PATH}/uuid/uuid_gen_test.cpp)
+#target_link_libraries(uuid_gen_test ${CGREEN_LIBRARY} uprotocolsdk)
+#add_test("t-05-uuid-gen-test" uuid_gen_test)
 
-target_link_libraries(ce_factory_test ${OPENSSL_LIBRARIES} ${CGREEN_LIBRARY} uprotocolsdk)
+
+add_executable(base64_test ${TESTS_PATH}/tools/base64_test.cpp)
+
+target_link_libraries(base64_test ${OPENSSL_LIBRARIES} ${CGREEN_LIBRARY} uprotocolsdk)
+
+add_test("t-06-base64-test" base64_test)
+
+
 
 add_test("t-07-ce-factory-test" base64_test)
 add_executable(service_type_test ${TESTS_PATH}/model/serviceType_test.cpp)
@@ -64,53 +74,33 @@ target_link_libraries(service_type_test ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-08-service-type-test" service_type_test)
 
 add_executable(UAuthorityTest
-	${TESTS_PATH}/uri/datamodel/UAuthorityTest.cpp)
-target_link_libraries(UAuthorityTest ${CGREEN_LIBRARY} uprotocolsdk)
+	${TESTS_PATH}/uri/UAuthorityTest.cpp)
+target_link_libraries(UAuthorityTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-09-UAuthorityTest" UAuthorityTest)
 
 add_executable(UEntityTest
-		${TESTS_PATH}/uri/datamodel/UEntityTest.cpp)
-target_link_libraries(UEntityTest ${CGREEN_LIBRARY} uprotocolsdk)
+		${TESTS_PATH}/uri/UEntityTest.cpp)
+target_link_libraries(UEntityTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
 add_test("t-10-UEntityTest" UEntityTest)
 
 add_executable(UResourceTest
-	${TESTS_PATH}/uri/datamodel/UResourceTest.cpp)
-target_link_libraries(UResourceTest ${CGREEN_LIBRARY} uprotocolsdk)
+	${TESTS_PATH}/uri/UResourceTest.cpp)
+target_link_libraries(UResourceTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
 add_test("t-11-UResourceTest" UResourceTest)
 
 add_executable(UUriTest
-	${TESTS_PATH}/uri/datamodel/UUriTest.cpp)
-target_link_libraries(UUriTest ${CGREEN_LIBRARY} uprotocolsdk)
+	${TESTS_PATH}/uri/UUriTest.cpp)
+target_link_libraries(UUriTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
 add_test("t-12-UUriTest" UUriTest)
 
 add_executable(LongUriSerializerTest
-		${TESTS_PATH}/uri/serializer/LongUriSerializerTest.cpp)
+	${TESTS_PATH}/uri/LongUriSerializerTest.cpp)
 target_compile_options(LongUriSerializerTest PRIVATE -g -O0)
-target_link_libraries(LongUriSerializerTest ${CGREEN_LIBRARY} uprotocolsdk)
+target_link_libraries(LongUriSerializerTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
 add_test("t-13-LongUriSerializerTest"  LongUriSerializerTest)
 
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-add_executable(uattributes_test
-	${TESTS_PATH}/utransport/uattributes_test.cpp)
-target_link_libraries(uattributes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-add_executable(umessagetypes_test
-	${TESTS_PATH}/utransport/umessagetypes_test.cpp)
-target_link_libraries(umessagetypes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-add_executable(upayload_test
-	${TESTS_PATH}/utransport/upayload_test.cpp)
-target_link_libraries(upayload_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-add_executable(upriority_test
-	${TESTS_PATH}/utransport/upriority_test.cpp)
-target_link_libraries(upriority_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
-add_executable(userializationhint_test
-	${TESTS_PATH}/utransport/userializationhint_test.cpp)
-target_link_libraries(userializationhint_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
-
+add_executable(MicroUriSerializerTest
+	${TESTS_PATH}/uri/MicroUriSerializerTest.cpp)
+target_compile_options(MicroUriSerializerTest PRIVATE -g -O0)
+target_link_libraries(MicroUriSerializerTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+add_test("t-14-MicroUriSerializerTest"  MicroUriSerializerTest)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(uuid_test ${GTEST_LIB} uprotocolsdk)
 add_test("t-04-uuid-test" uuid_test)
 
 add_executable(base64_test ${TESTS_PATH}/tools/base64_test.cpp)
-target_link_libraries(base64_test ${OPENSSL_LIBRARIES} ${CGREEN_LIBRARY} uprotocolsdk)
+target_link_libraries(base64_test ${OPENSSL_LIBRARIES} ${GTEST_LIB} gtest_main uprotocolsdk)
 add_test("t-05-base64-test" base64_test)
 
 add_test("t-06-ce-factory-test" base64_test)
@@ -90,24 +90,24 @@ add_test("t-13-MicroUriSerializerTest"  MicroUriSerializerTest)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(uattributes_test
 	${TESTS_PATH}/utransport/uattributes_test.cpp)
-target_link_libraries(uattributes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+target_link_libraries(uattributes_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(umessagetypes_test
 	${TESTS_PATH}/utransport/umessagetypes_test.cpp)
-target_link_libraries(umessagetypes_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+target_link_libraries(umessagetypes_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(upayload_test
 	${TESTS_PATH}/utransport/upayload_test.cpp)
-target_link_libraries(upayload_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+target_link_libraries(upayload_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(upriority_test
 	${TESTS_PATH}/utransport/upriority_test.cpp)
-target_link_libraries(upriority_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+target_link_libraries(upriority_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(userializationhint_test
 	${TESTS_PATH}/utransport/userializationhint_test.cpp)
-target_link_libraries(userializationhint_test ${CGREEN_LIBRARY} uprotocolsdk gtest gtest_main)
+target_link_libraries(userializationhint_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,23 +91,28 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(uattributes_test
 	${TESTS_PATH}/utransport/uattributes_test.cpp)
 target_link_libraries(uattributes_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
+add_test("t-14-uattributes_test"  uattributes_test)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(umessagetypes_test
 	${TESTS_PATH}/utransport/umessagetypes_test.cpp)
 target_link_libraries(umessagetypes_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
+add_test("t-15-umessagetypes_test"  umessagetypes_test)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(upayload_test
 	${TESTS_PATH}/utransport/upayload_test.cpp)
 target_link_libraries(upayload_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
+add_test("t-16-upayload_test"  upayload_test)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(upriority_test
 	${TESTS_PATH}/utransport/upriority_test.cpp)
 target_link_libraries(upriority_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
+add_test("t-17-upriority_test"  upriority_test)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../)
 add_executable(userializationhint_test
 	${TESTS_PATH}/utransport/userializationhint_test.cpp)
 target_link_libraries(userializationhint_test ${CGREEN_LIBRARY} uprotocolsdk ${GTEST_LIB}  gtest_main)
+add_test("t-18-MicroUriSerializerTest"  userializationhint_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,33 +74,33 @@ target_link_libraries(service_type_test ${CGREEN_LIBRARY} uprotocolsdk)
 add_test("t-08-service-type-test" service_type_test)
 
 add_executable(UAuthorityTest
-	${TESTS_PATH}/uri/UAuthorityTest.cpp)
+	${TESTS_PATH}/uri/datamodel/UAuthorityTest.cpp)
 target_link_libraries(UAuthorityTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-09-UAuthorityTest" UAuthorityTest)
 
 add_executable(UEntityTest
-		${TESTS_PATH}/uri/UEntityTest.cpp)
-target_link_libraries(UEntityTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+		${TESTS_PATH}/uri/datamodel/UEntityTest.cpp)
+target_link_libraries(UEntityTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-10-UEntityTest" UEntityTest)
 
 add_executable(UResourceTest
-	${TESTS_PATH}/uri/UResourceTest.cpp)
-target_link_libraries(UResourceTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+	${TESTS_PATH}/uri/datamodel/UResourceTest.cpp)
+target_link_libraries(UResourceTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-11-UResourceTest" UResourceTest)
 
 add_executable(UUriTest
-	${TESTS_PATH}/uri/UUriTest.cpp)
-target_link_libraries(UUriTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+	${TESTS_PATH}/uri/datamodel/UUriTest.cpp)
+target_link_libraries(UUriTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-12-UUriTest" UUriTest)
 
 add_executable(LongUriSerializerTest
-	${TESTS_PATH}/uri/LongUriSerializerTest.cpp)
+	${TESTS_PATH}/uri/serializer/LongUriSerializerTest.cpp)
 target_compile_options(LongUriSerializerTest PRIVATE -g -O0)
-target_link_libraries(LongUriSerializerTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+target_link_libraries(LongUriSerializerTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-13-LongUriSerializerTest"  LongUriSerializerTest)
 
 add_executable(MicroUriSerializerTest
-	${TESTS_PATH}/uri/MicroUriSerializerTest.cpp)
+	${TESTS_PATH}/uri/serializer/MicroUriSerializerTest.cpp)
 target_compile_options(MicroUriSerializerTest PRIVATE -g -O0)
-target_link_libraries(MicroUriSerializerTest ${CGREEN_LIBRARY} ${GTEST_LIB} uprotocolsdk)
+target_link_libraries(MicroUriSerializerTest ${GTEST_LIB} uprotocolsdk)
 add_test("t-14-MicroUriSerializerTest"  MicroUriSerializerTest)

--- a/test/uri/datamodel/UAuthorityTest.cpp
+++ b/test/uri/datamodel/UAuthorityTest.cpp
@@ -18,292 +18,259 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <gtest/gtest.h>
 #include <string>
-#include <cgreen/cgreen.h>
 #include "UAuthority.h"
 
-using namespace cgreen;
+
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(UAuthority);
-
-BeforeEach(UAuthority) {
-    // Dummy
-}
-
-AfterEach(UAuthority) {
-    // Dummy
-}
-
 // Make sure the toString works.
-static void testToString() {
+TEST(UAuthorityTest, ToString)
+{
     UAuthority longRemote = UAuthority::longRemote("VCU", "my_VIN");
     std::string expected = "UAuthority{device='vcu', domain='my_vin', address=null, markedRemote=true, markedResolved=false}";
-    assertEquals(expected, longRemote.toString());
+    EXPECT_EQ(expected, longRemote.toString());
 
     std::string address = "127.0.0.1";
     UAuthority microRemote = UAuthority::microRemote(address);
     expected = "UAuthority{device='null', domain='null', address=127.0.0.1, markedRemote=true, markedResolved=false}";
-    assertEquals(expected, microRemote.toString());
+    EXPECT_EQ(expected, microRemote.toString());
 
     UAuthority resolvedRemote = UAuthority::resolvedRemote("VCU", "MY_VIN", address);
     expected = "UAuthority{device='vcu', domain='my_vin', address=127.0.0.1, markedRemote=true, markedResolved=true}";
-    assertEquals(expected, resolvedRemote.toString());
+    EXPECT_EQ(expected, resolvedRemote.toString());
 
     UAuthority local = UAuthority::local();
     expected = "UAuthority{device='null', domain='null', address=null, markedRemote=false, markedResolved=true}";
-    assertEquals(expected, local.toString());
+    EXPECT_EQ(expected, local.toString());
 
     UAuthority empty = UAuthority::empty();
     expected = "UAuthority{device='null', domain='null', address=null, markedRemote=false, markedResolved=true}";
-    assertEquals(expected, empty.toString());
+    EXPECT_EQ(expected, empty.toString());
 }
 
 // Make sure the toString works with case sensitivity.
-static void testToStringCaseSensitivity() {
+TEST(UAuthorityTest, ToStringCaseSensitivity)
+{
     UAuthority uAuthority = UAuthority::longRemote("vcU", "my_VIN");
     std::string expected = "UAuthority{device='vcu', domain='my_vin', address=null, markedRemote=true, markedResolved=false}";
-    assertEquals(expected, uAuthority.toString());
+    EXPECT_EQ(expected, uAuthority.toString());
 }
 
 // Test create a empty uAuthority.
-static void testEmptyUAuthority() {
+TEST(UAuthorityTest, EmptyUAuthority) {
     UAuthority uAuthority = UAuthority::empty();
-    assertTrue(uAuthority.getDevice().empty());
-    assertTrue(uAuthority.getDomain().empty());
-    assertTrue(uAuthority.getAddress().empty());
-    assertTrue(uAuthority.isLocal());
-    assertFalse(uAuthority.isRemote());
-    assertFalse(uAuthority.isMarkedRemote());
-    assertTrue(uAuthority.isResolved());
-    assertTrue(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_TRUE(uAuthority.isLocal());
+    EXPECT_FALSE(uAuthority.isRemote());
+    EXPECT_FALSE(uAuthority.isMarkedRemote());
+    EXPECT_TRUE(uAuthority.isResolved());
+    EXPECT_TRUE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a local uAuthority.
-static void testLocalUAuthority() {
+TEST(UAuthorityTest, LocalUAuthority) {
     UAuthority uAuthority = UAuthority::local();
-    assertTrue(uAuthority.getDevice().empty());
-    assertTrue(uAuthority.getDomain().empty());
-    assertTrue(uAuthority.getAddress().empty());
-    assertTrue(uAuthority.isLocal());
-    assertFalse(uAuthority.isRemote());
-    assertFalse(uAuthority.isMarkedRemote());
-    assertTrue(uAuthority.isResolved());
-    assertTrue(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_TRUE(uAuthority.isLocal());
+    EXPECT_FALSE(uAuthority.isRemote());
+    EXPECT_FALSE(uAuthority.isMarkedRemote());
+    EXPECT_TRUE(uAuthority.isResolved());
+    EXPECT_TRUE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a remote uAuthority that supports long UUris.
-static void testLongRemoteUAuthority() {
+TEST(UAuthorityTest, LongRemoteUAuthority) {
     std::string device = "vcu";
     std::string domain = "myvin";
     UAuthority uAuthority = UAuthority::longRemote(device, domain);
-    assertEquals(device, uAuthority.getDevice());
-    assertEquals(domain, uAuthority.getDomain());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_EQ(device, uAuthority.getDevice());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a remote uAuthority that supports long UUris null device.
-static void testLongRemoteEmptyDevice() {
+TEST(UAuthorityTest, LongRemoteEmptyDevice) {
     std::string domain = "myvin";
     UAuthority uAuthority = UAuthority::longRemote("", domain);
-    assertTrue(uAuthority.getDevice().empty());
-    assertEquals(domain, uAuthority.getDomain());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
 // Test create a remote uAuthority that supports long UUris missing device.
-static void testLongUriBlankDevice() {
+TEST(UAuthorityTest, LongUriBlankDevice) {
     std::string device = " ";
     std::string domain = "myvin";
     UAuthority uAuthority = UAuthority::longRemote(device, domain);
-    assertTrue(uAuthority.getDevice().empty());
-    assertEquals(domain, uAuthority.getDomain());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
 // Test create a remote uAuthority that supports long UUris null domain.
-static void testLongUriEmptyDomain() {
+TEST(UAuthorityTest, LongUriEmptyDomain) {
     std::string device = "vcu";
     UAuthority uAuthority = UAuthority::longRemote(device, "");
-    assertEquals(device, uAuthority.getDevice());
-    assertTrue(uAuthority.getDomain().empty());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_EQ(device, uAuthority.getDevice());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a remote uAuthority that supports micro UUris.
-static void testMicroUriUAuthority() {
+TEST(UAuthorityTest, MicroUriUAuthority) {
     std::string address = "127.0.0.1";
     UAuthority uAuthority = UAuthority::microRemote(address);
-    assertTrue(uAuthority.getDevice().empty());
-    assertTrue(uAuthority.getDomain().empty());
-    assertEquals(address, uAuthority.getAddress());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_EQ(address, uAuthority.getAddress());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
-
 // Test create a remote uAuthority that supports micro UUris with null address.
-static void testMicroUriEmptyAddress() {
+TEST(UAuthorityTest, MicroUriEmptyAddress) {
     UAuthority uAuthority = UAuthority::microRemote("");
-    assertTrue(uAuthority.getDevice().empty());
-    assertTrue(uAuthority.getDomain().empty());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertTrue(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_TRUE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
 // Test create a remote resolved uAuthority that supports both long and micro UUris.
-static void testResolvedRemoteUAuthority() {
+TEST(UAuthorityTest, ResolvedRemoteUAuthority) {
     std::string device = "vcu";
     std::string domain = "myvin";
     std::string address = "127.0.0.1";
     UAuthority uAuthority = UAuthority::resolvedRemote(device, domain, address);
-    assertEquals(device, uAuthority.getDevice());
-    assertEquals(domain, uAuthority.getDomain());
-    assertEquals(address, uAuthority.getAddress());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertTrue(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_EQ(device, uAuthority.getDevice());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_EQ(address, uAuthority.getAddress());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_TRUE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a remote resolved uAuthority that supports both long and micro UUris with null device.
-static void testResolvedRemoteUAuthorityEmptyDevice() {
+TEST(UAuthorityTest, ResolvedRemoteUAuthorityEmptyDevice) {
     std::string domain = "myvin";
     std::string address = "127.0.0.1";
     UAuthority uAuthority = UAuthority::resolvedRemote("", domain, address);
-    assertTrue(uAuthority.getDevice().empty());
-    assertEquals(domain, uAuthority.getDomain());
-    assertEquals(address, uAuthority.getAddress());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_EQ(address, uAuthority.getAddress());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
 // Test create a remote resolved uAuthority that supports both long and micro UUris with blank device.
-static void testResolvedRemoteUAuthorityBlankDevice() {
+TEST(UAuthorityTest, ResolvedRemoteUAuthorityBlankDevice) {
     std::string device = "  ";
     std::string domain = "myvin";
     std::string address = "127.0.0.1";
     UAuthority uAuthority = UAuthority::resolvedRemote(device, domain, address);
-    assertTrue(uAuthority.getDevice().empty());
-    assertEquals(domain, uAuthority.getDomain());
-    assertEquals(address, uAuthority.getAddress());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertTrue(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_EQ(address, uAuthority.getAddress());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_TRUE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
 // Test create a remote resolved uAuthority that supports both long and micro UUris with missing address.
-static void testResolvedRemoteUAuthorityEmptyAddress() {
+TEST(UAuthorityTest, ResolvedRemoteUAuthorityEmptyAddress) {
     std::string device = "vcu";
     std::string domain = "myvin";
     UAuthority uAuthority = UAuthority::resolvedRemote(device, domain, "");
-    assertEquals(device, uAuthority.getDevice());
-    assertEquals(domain, uAuthority.getDomain());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertFalse(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertTrue(uAuthority.isLongForm());
+    EXPECT_EQ(device, uAuthority.getDevice());
+    EXPECT_EQ(domain, uAuthority.getDomain());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_FALSE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_TRUE(uAuthority.isLongForm());
 }
 
 // Test create a remote resolved uAuthority that supports both long and micro UUris with missing data.
-static void testResolvedRemoteUAuthorityEmptyData() {
+TEST(UAuthorityTest, ResolvedRemoteUAuthorityEmptyData) {
     UAuthority uAuthority = UAuthority::resolvedRemote("", "", "");
-    assertTrue(uAuthority.getDevice().empty());
-    assertTrue(uAuthority.getDomain().empty());
-    assertTrue(uAuthority.getAddress().empty());
-    assertFalse(uAuthority.isLocal());
-    assertTrue(uAuthority.isRemote());
-    assertTrue(uAuthority.isMarkedRemote());
-    assertFalse(uAuthority.isResolved());
-    assertTrue(uAuthority.isEmpty());
-    assertFalse(uAuthority.isMicroForm());
-    assertFalse(uAuthority.isLongForm());
+    EXPECT_TRUE(uAuthority.getDevice().empty());
+    EXPECT_TRUE(uAuthority.getDomain().empty());
+    EXPECT_TRUE(uAuthority.getAddress().empty());
+    EXPECT_FALSE(uAuthority.isLocal());
+    EXPECT_TRUE(uAuthority.isRemote());
+    EXPECT_TRUE(uAuthority.isMarkedRemote());
+    EXPECT_FALSE(uAuthority.isResolved());
+    EXPECT_TRUE(uAuthority.isEmpty());
+    EXPECT_FALSE(uAuthority.isMicroForm());
+    EXPECT_FALSE(uAuthority.isLongForm());
 }
 
-Ensure(UAuthority, all_tests) {
-    testToString();
-    testToStringCaseSensitivity();
-    testEmptyUAuthority();
-    testLocalUAuthority();
-    testLongRemoteUAuthority();
-    testLongRemoteEmptyDevice();
-    testLongUriBlankDevice();
-    testLongUriEmptyDomain();
-    testMicroUriUAuthority();
-    testMicroUriEmptyAddress();
-    testResolvedRemoteUAuthority();
-    testResolvedRemoteUAuthorityEmptyDevice();
-    testResolvedRemoteUAuthorityBlankDevice();
-    testResolvedRemoteUAuthorityEmptyAddress();
-    testResolvedRemoteUAuthorityEmptyData();
-}
-
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, UAuthority, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UAuthorityTest.cpp
+++ b/test/uri/datamodel/UAuthorityTest.cpp
@@ -26,8 +26,7 @@
 using namespace uprotocol::uri;
 
 // Make sure the toString works.
-TEST(UAuthorityTest, ToString)
-{
+TEST(UAuthorityTest, ToString) {
     UAuthority longRemote = UAuthority::longRemote("VCU", "my_VIN");
     std::string expected = "UAuthority{device='vcu', domain='my_vin', address=null, markedRemote=true, markedResolved=false}";
     EXPECT_EQ(expected, longRemote.toString());
@@ -51,8 +50,7 @@ TEST(UAuthorityTest, ToString)
 }
 
 // Make sure the toString works with case sensitivity.
-TEST(UAuthorityTest, ToStringCaseSensitivity)
-{
+TEST(UAuthorityTest, ToStringCaseSensitivity) {
     UAuthority uAuthority = UAuthority::longRemote("vcU", "my_VIN");
     std::string expected = "UAuthority{device='vcu', domain='my_vin', address=null, markedRemote=true, markedResolved=false}";
     EXPECT_EQ(expected, uAuthority.toString());
@@ -269,8 +267,7 @@ TEST(UAuthorityTest, ResolvedRemoteUAuthorityEmptyData) {
     EXPECT_FALSE(uAuthority.isLongForm());
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UEntityTest.cpp
+++ b/test/uri/datamodel/UEntityTest.cpp
@@ -20,296 +20,258 @@
  */
 #include <string>
 #include <optional>
-#include <cgreen/cgreen.h>
+#include <gtest/gtest.h>
 #include "UEntity.h"
 
-using namespace cgreen;
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(UEntity);
-
-BeforeEach(UEntity) {
-    // Dummy
-}
-
-AfterEach(UEntity) {
-    // Dummy
-}
-
 // Make sure the toString works.
-static void testToString() {
+TEST(UEntityTest, ToString) {
     UEntity uEntity = UEntity::longFormat("body.access", 1);
-    assertEquals("body.access", uEntity.getName());
-    assertTrue(uEntity.getVersion().has_value());
-    assertEquals(1, uEntity.getVersion().value());
+    EXPECT_EQ("body.access", uEntity.getName());
+    EXPECT_TRUE(uEntity.getVersion().has_value());
+    EXPECT_EQ(1, uEntity.getVersion().value());
 
     std::string expected = "UEntity{name='body.access', version=1, id=null, markedResolved=false}";
-    assertEquals(expected, uEntity.toString());
+    EXPECT_EQ(expected, uEntity.toString());
 
     UEntity uEntity2 = UEntity::longFormat("body.access");
     expected = "UEntity{name='body.access', version=null, id=null, markedResolved=false}";
-    assertEquals(expected, uEntity2.toString());
+    EXPECT_EQ(expected, uEntity2.toString());
 }
 
 // Test creating an empty USE using the empty static method.
-static void testEmptyEntity() {
+TEST(UEntityTest, EmptyEntity) {
     UEntity uEntity = UEntity::empty();
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with name.
-static void testLongFormatWithName() {
+TEST(UEntityTest, LongFormatWithName) {
     UEntity uEntity = UEntity::longFormat("body.access");
-    assertEquals("body.access", uEntity.getName());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertTrue(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_EQ("body.access", uEntity.getName());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_TRUE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with name that is blank.
-static void testLongFormatWithBlankName() {
+TEST(UEntityTest, LongFormatWithBlankName) {
     UEntity uEntity = UEntity::longFormat("  ");
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with name that is null, expect exception.
-static void testLongFormatWithEmptyName() {
+TEST(UEntityTest, LongFormatWithEmptyName) {
     UEntity uEntity = UEntity::longFormat("");
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with name and version.
-static void testLongFormatWithNameAndVersion() {
+TEST(UEntityTest, LongFormatWithNameAndVersion) {
     UEntity uEntity = UEntity::longFormat("body.access", 1);
-    assertEquals("body.access", uEntity.getName());
-    assertEquals(1, uEntity.getVersion().value_or(-1));
-    assertFalse(uEntity.getId().has_value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertTrue(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_EQ("body.access", uEntity.getName());
+    EXPECT_EQ(1, uEntity.getVersion().value_or(-1));
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_TRUE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with blank name and null version.
-static void testLongFormatWithEmptyNameAndNoVersion() {
+TEST(UEntityTest, LongFormatWithEmptyNameAndNoVersion) {
     UEntity uEntity = UEntity::longFormat("", std::nullopt);
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with blank name and null version.
-static void testLongFormatWithNameAndNoVersion() {
+TEST(UEntityTest, LongFormatWithNameAndNoVersion) {
     UEntity uEntity = UEntity::longFormat("body.access", std::nullopt);
-    assertEquals("body.access", uEntity.getName());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertTrue(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_EQ("body.access", uEntity.getName());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_TRUE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in long format UUri with name and version, null name, expect exception.
-static void testLongFormatWithVersionAndNoName() {
+TEST(UEntityTest, LongFormatWithVersionAndNoName) {
     UEntity uEntity = UEntity::longFormat("", 1);
-    assertTrue(uEntity.getName().empty());
-    assertTrue(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_TRUE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in micro format UUri with id.
-static void testMicroFormatWithId() {
+TEST(UEntityTest, MicroFormatWithId) {
     uint16_t id = 42;
     UEntity uEntity = UEntity::microFormat(id);
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in micro format UUri with null id.
-static void testMicroFormatWithNoId() {
+TEST(UEntityTest, MicroFormatWithNoId) {
     UEntity uEntity = UEntity::microFormat(std::nullopt);
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in micro format UUri with id and version.
-static void testMicroFormatWithIdAndVersion() {
+TEST(UEntityTest, MicroFormatWithIdAndVersion) {
     uint16_t id = 42;
     uint16_t version = 1;
     UEntity uEntity = UEntity::microFormat(id, version);
-    assertTrue(uEntity.getName().empty());
-    assertEquals(version, uEntity.getVersion().value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_EQ(version, uEntity.getVersion().value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in micro format UUri with id and null version.
-static void testMicroFormatWithIdAndNoVersion() {
+TEST(UEntityTest, MicroFormatWithIdAndNoVersion) {
     uint16_t id = 42;
     UEntity uEntity = UEntity::microFormat(id, std::nullopt);
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a software entity for use in micro format UUri with null id and version.
-static void testMicroFormatWithVersionAndNoId() {
+TEST(UEntityTest, MicroFormatWithVersionAndNoId) {
     uint8_t version = 1;
     UEntity uEntity = UEntity::microFormat(std::nullopt, version);
-    assertTrue(uEntity.getName().empty());
-    assertTrue(uEntity.getVersion().value());
-    assertFalse(uEntity.getId().has_value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_TRUE(uEntity.getVersion().value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
 // Test creating a resolved software entity for use in long format and micro format UUri.
-static void testResolvedFormat() {
+TEST(UEntityTest, ResolvedFormat) {
     uint16_t id = 42;
     uint8_t version = 1;
     UEntity uEntity = UEntity::resolvedFormat("body.access", version, id);
-    assertEquals("body.access", uEntity.getName());
-    assertEquals(version, uEntity.getVersion().value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertTrue(uEntity.isResolved());
-    assertTrue(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_EQ("body.access", uEntity.getName());
+    EXPECT_EQ(version, uEntity.getVersion().value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_TRUE(uEntity.isResolved());
+    EXPECT_TRUE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a resolved software entity for use in long format and micro format UUri when name is empty.
-static void testResolvedFormatWithEmptyName() {
+TEST(UEntityTest, ResolvedFormatWithEmptyName) {
     uint16_t id = 42;
     uint8_t version = 1;
     UEntity uEntity = UEntity::resolvedFormat(" ", 1, id);
-    assertTrue(uEntity.getName().empty());
-    assertEquals(version, uEntity.getVersion().value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_EQ(version, uEntity.getVersion().value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a resolved software entity for use in long format and micro format UUri when name is null.
-static void testResolvedFormatWithNoName() {
+TEST(UEntityTest, ResolvedFormatWithNoName) {
     uint16_t id = 42;
     uint8_t version = 1;
     UEntity uEntity = UEntity::resolvedFormat("", version, id);
-    assertTrue(uEntity.getName().empty());
-    assertEquals(version, uEntity.getVersion().value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_EQ(version, uEntity.getVersion().value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a resolved software entity for use in long format and micro format UUri with missing version.
-static void testResolvedFormatWithNoVersion() {
+TEST(UEntityTest, ResolvedFormatWithNoVersion) {
     std::string name = "body.access";
     uint16_t id = 42;
     UEntity uEntity = UEntity::resolvedFormat(name, std::nullopt, id);
-    assertEquals(name, uEntity.getName());
-    assertFalse(uEntity.getVersion().has_value());
-    assertEquals(id, uEntity.getId().value());
-    assertFalse(uEntity.isEmpty());
-    assertTrue(uEntity.isResolved());
-    assertTrue(uEntity.isLongForm());
-    assertTrue(uEntity.isMicroForm());
+    EXPECT_EQ(name, uEntity.getName());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_EQ(id, uEntity.getId().value());
+    EXPECT_FALSE(uEntity.isEmpty());
+    EXPECT_TRUE(uEntity.isResolved());
+    EXPECT_TRUE(uEntity.isLongForm());
+    EXPECT_TRUE(uEntity.isMicroForm());
 }
 
 // Test creating a resolved software entity for use in long format and micro format UUri when all elements are empty.
-static void testResolvedFormatEmpty() {
+TEST(UEntityTest, ResolvedFormatEmpty) {
     UEntity uEntity = UEntity::resolvedFormat("  ", std::nullopt, std::nullopt);
-    assertTrue(uEntity.getName().empty());
-    assertFalse(uEntity.getVersion().has_value());
-    assertFalse(uEntity.getId().has_value());
-    assertTrue(uEntity.isEmpty());
-    assertFalse(uEntity.isResolved());
-    assertFalse(uEntity.isLongForm());
-    assertFalse(uEntity.isMicroForm());
+    EXPECT_TRUE(uEntity.getName().empty());
+    EXPECT_FALSE(uEntity.getVersion().has_value());
+    EXPECT_FALSE(uEntity.getId().has_value());
+    EXPECT_TRUE(uEntity.isEmpty());
+    EXPECT_FALSE(uEntity.isResolved());
+    EXPECT_FALSE(uEntity.isLongForm());
+    EXPECT_FALSE(uEntity.isMicroForm());
 }
 
-Ensure(UEntity, all_tests) {
-    testToString();
-    testEmptyEntity();
-    testLongFormatWithName();
-    testLongFormatWithBlankName();
-    testLongFormatWithEmptyName();
-    testLongFormatWithNameAndVersion();
-    testLongFormatWithEmptyNameAndNoVersion();
-    testLongFormatWithNameAndNoVersion();
-    testLongFormatWithVersionAndNoName();
-    testMicroFormatWithId();
-    testMicroFormatWithNoId();
-    testMicroFormatWithIdAndVersion();
-    testMicroFormatWithIdAndNoVersion();
-    testMicroFormatWithVersionAndNoId();
-    testResolvedFormat();
-    testResolvedFormatWithEmptyName();
-    testResolvedFormatWithNoName();
-    testResolvedFormatWithNoVersion();
-    testResolvedFormatEmpty();
-}
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, UEntity, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UEntityTest.cpp
+++ b/test/uri/datamodel/UEntityTest.cpp
@@ -269,9 +269,7 @@ TEST(UEntityTest, ResolvedFormatEmpty) {
     EXPECT_FALSE(uEntity.isMicroForm());
 }
 
-
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UResourceTest.cpp
+++ b/test/uri/datamodel/UResourceTest.cpp
@@ -19,511 +19,462 @@
  * under the License.
  */
 #include <string>
-#include <cgreen/cgreen.h>
+#include <gtest/gtest.h>
 #include "UResource.h"
 
-using namespace cgreen;
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(UResource);
-
-BeforeEach(UResource) {
-    // Dummy
-}
-
-AfterEach(UResource) {
-    // Dummy
-}
-
 // Make sure the toString works.
-static void testToString() {
+TEST(UResourceTest, ToString)
+{
     UResource uResource = UResource::longFormat("door", "front_left", "Door");
     std::string expected("UResource{name='door', instance='front_left', message='Door', id=null, markedResolved=false}");
-    assertEquals(expected, uResource.toString());
-    assertFalse(uResource.isEmpty());
+    EXPECT_EQ(expected, uResource.toString());
+    EXPECT_FALSE(uResource.isEmpty());
 }
 
 // Test creating a empty Resource.
-static void testEmptyResource() {
+TEST(UResourceTest, EmptyResource) {
     UResource uResource = UResource::empty();
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a complete up Resource in long format.
-static void testLongFormat() {
+TEST(UResourceTest, LongFormat) {
     std::string name("door");
     std::string instance("front_left");
     std::string message("Door");
     UResource uResource = UResource::longFormat(name, instance, message);
-    assertEquals(name, uResource.getName());
-    assertEquals(instance, uResource.getInstance());
-    assertEquals(message, uResource.getMessage());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with no name.
-static void testLongFormatWithoutName() {
+TEST(UResourceTest, LongFormatWithoutName) {
     std::string instance("front_left");
     std::string message("Door");
     UResource uResource = UResource::longFormat("", instance, message);
-    assertTrue(uResource.getName().empty());
-    assertEquals(instance, uResource.getInstance());
-    assertEquals(message, uResource.getMessage());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with no instance.
-static void testLongFormatWithoutInstance() {
+TEST(UResourceTest, LongFormatWithoutInstance) {
     std::string name("door");
     std::string message("Door");
     UResource uResource = UResource::longFormat(name, "", message);
-    assertEquals(name, uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertEquals(message, uResource.getMessage());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with no message.
-static void testLongFormatWithoutMessage() {
+TEST(UResourceTest, LongFormatWithoutMessage) {
     std::string name("door");
     std::string instance("front_left");
     UResource uResource = UResource::longFormat(name, instance, "");
-    assertEquals(name, uResource.getName());
-    assertEquals(instance, uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with empty inputs.
-static void testLongFormatEmpty() {
+TEST(UResourceTest, LongFormatEmpty) {
     UResource uResource = UResource::longFormat("", "", "");
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with empty values.
-static void testLongFormatWithBlankValues() {
+TEST(UResourceTest, LongFormatWithBlankValues) {
     UResource uResource = UResource::longFormat(" ", " ", " ");
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with name.
-static void testLongFormatWithName() {
+TEST(UResourceTest, LongFormatWithName) {
     std::string name("door");
     UResource uResource = UResource::longFormat(name);
-    assertEquals(name, uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with name empty.
-static void testLongFormatWithNameEmpty() {
+TEST(UResourceTest, LongFormatWithNameEmpty) {
     UResource uResource = UResource::longFormat("");
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in long format with name blank.
-static void testLongFormatWithNameBlank() {
+TEST(UResourceTest, LongFormatWithNameBlank) {
     UResource uResource = UResource::longFormat("  ");
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource in micro format.
-static void testMicroFormat() {
+TEST(UResourceTest, MicroFormat) {
     uint16_t id = 42;
     UResource uResource = UResource::microFormat(id);
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a Resource to be used in micro formatted UUri id is null.
-static void testMicroFormatWithoutId() {
+TEST(UResourceTest, MicroFormatWithoutId) {
     UResource uResource = UResource::microFormat(std::nullopt);
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource to be used in long and micro formatted UUri.
-static void testResolvedFormat() {
+TEST(UResourceTest, ResolvedFormat) {
     std::string name("door");
     std::string instance("front_left");
     std::string message("Door");
     uint16_t id = 42;
     UResource uResource = UResource::resolvedFormat(name, instance, message, id);
-    assertEquals(name, uResource.getName());
-    assertEquals(instance, uResource.getInstance());
-    assertEquals(message, uResource.getMessage());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertTrue(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_TRUE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource with empty name.
-static void testResolvedFormatEmptyName() {
+TEST(UResourceTest, ResolvedFormatEmptyName) {
     std::string instance("front_left");
     std::string message("Door");
     uint16_t id = 42;
     UResource uResource = UResource::resolvedFormat("  ", instance, message, id);
-    assertTrue(uResource.getName().empty());
-    assertEquals(instance, uResource.getInstance());
-    assertEquals(message, uResource.getMessage());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource with empty instance.
-static void testResolvedFormatEmptyInstance() {
+TEST(UResourceTest, ResolvedFormatEmptyInstance) {
     std::string name("door");
     std::string message("Door");
     uint16_t id = 42;
     UResource uResource = UResource::resolvedFormat(name, "  ", message, id);
-    assertEquals(name, uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertEquals(message, uResource.getMessage());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertTrue(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_TRUE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource with empty message.
-static void testResolvedFormatEmptyMessage() {
+TEST(UResourceTest, ResolvedFormatEmptyMessage) {
     std::string name("door");
     std::string instance("front_left");
     uint16_t id = 42;
     UResource uResource = UResource::resolvedFormat(name, instance, "  ", id);
-    assertEquals(name, uResource.getName());
-    assertEquals(instance, uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertTrue(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_TRUE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource with empty id.
-static void testResolvedFormatEmptyId() {
+TEST(UResourceTest, ResolvedFormatEmptyId) {
     std::string name("door");
     std::string instance("front_left");
     std::string message("Door");
     UResource uResource = UResource::resolvedFormat(name, instance, message, std::nullopt);
-    assertEquals(name, uResource.getName());
-    assertEquals(instance, uResource.getInstance());
-    assertEquals(message, uResource.getMessage());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ(name, uResource.getName());
+    EXPECT_EQ(instance, uResource.getInstance());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating a fully resolved Resource with empty values.
-static void testResolvedFormatEmptyValues() {
+TEST(UResourceTest, ResolvedFormatEmptyValues) {
     UResource uResource = UResource::resolvedFormat(" ", " ", " ", std::nullopt);
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating invalid uResource with only the message.
-static void testResolvedFormatWithOnlyMessage() {
+TEST(UResourceTest, ResolvedFormatWithOnlyMessage) {
     std::string message("Door");
     UResource uResource = UResource::resolvedFormat("", "", message, std::nullopt);
-    assertTrue(uResource.getName().empty());
-    assertTrue(uResource.getInstance().empty());
-    assertEquals(message, uResource.getMessage());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_TRUE(uResource.getName().empty());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_EQ(message, uResource.getMessage());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating rpc request for long formatted UUri.
-static void testRpcRequestLongFormat() {
+TEST(UResourceTest, RpcRequestLongFormat) {
     std::string methodName = "ExecuteDoorCommand";
     UResource uResource = UResource::forRpcRequest(methodName);
-    assertEquals("rpc", uResource.getName());
-    assertEquals(methodName, uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_EQ(methodName, uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
 // Test creating rpc request for long formatted UUri with empty method name.
-static void testRpcRequestLongFormatEmptyMethodName() {
+TEST(UResourceTest, RpcRequestLongFormatEmptyMethodName) {
     UResource uResource = UResource::forRpcRequest("");
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating rpc request for long formatted UUri with blank method name.
-static void testRpcRequestLongFormatBlankMethodName() {
+TEST(UResourceTest, RpcRequestLongFormatBlankMethodName) {
     UResource uResource = UResource::forRpcRequest("  ");
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating rpc request for micro formatted UUri.
-static void testRpcRequestMicroFormat() {
+TEST(UResourceTest, RpcRequestMicroFormat) {
     uint16_t id = 42;
     UResource uResource = UResource::forRpcRequest(id);
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
 // Test creating rpc request for micro formatted UUri without id.
-static void testRpcRequestMicroFormatWithoutId() {
+TEST(UResourceTest, RpcRequestMicroFormatWithoutId) {
     UResource uResource = UResource::forRpcRequest(std::nullopt);
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating resolved rpc request for long and micro formatted UUri.
-static void testRpcRequestLongAndMicroFormat() {
+TEST(UResourceTest, RpcRequestLongAndMicroFormat) {
     std::string methodName = "ExecuteDoorCommand";
     uint16_t id = 42;
     UResource uResource = UResource::forRpcRequest(methodName, id);
-    assertEquals("rpc", uResource.getName());
-    assertEquals(methodName, uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertTrue(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_EQ(methodName, uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_TRUE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
 // Test creating resolved rpc request for long and micro formatted UUri without id.
-static void testRpcRequestLongAndMicroFormatWithoutId() {
+TEST(UResourceTest, RpcRequestLongAndMicroFormatWithoutId) {
     std::string methodName = "ExecuteDoorCommand";
     UResource uResource = UResource::forRpcRequest(methodName, std::nullopt);
-    assertEquals("rpc", uResource.getName());
-    assertEquals(methodName, uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_EQ(methodName, uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
 // Test creating resolved rpc request for long and micro formatted UUri without method name.
-static void testRpcRequestLongAndMicroFormatWithoutMethodName() {
+TEST(UResourceTest, RpcRequestLongAndMicroFormatWithoutMethodName) {
     uint16_t id = 42;
     UResource uResource = UResource::forRpcRequest(" ", id);
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(id, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(id, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
 // Test creating resolved rpc request for long and micro formatted UUri missing values.
-static void testRpcRequestLongAndMicroFormatWithoutValues() {
+TEST(UResourceTest, RpcRequestLongAndMicroFormatWithoutValues) {
     UResource uResource = UResource::forRpcRequest("", std::nullopt);
-    assertEquals("rpc", uResource.getName());
-    assertTrue(uResource.getInstance().empty());
-    assertTrue(uResource.getMessage().empty());
-    assertFalse(uResource.getId().has_value());
-    assertTrue(uResource.isEmpty());
-    assertFalse(uResource.isResolved());
-    assertFalse(uResource.isLongForm());
-    assertFalse(uResource.isMicroForm());
-    assertFalse(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_TRUE(uResource.getInstance().empty());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_FALSE(uResource.getId().has_value());
+    EXPECT_TRUE(uResource.isEmpty());
+    EXPECT_FALSE(uResource.isResolved());
+    EXPECT_FALSE(uResource.isLongForm());
+    EXPECT_FALSE(uResource.isMicroForm());
+    EXPECT_FALSE(uResource.isRPCMethod());
 }
 
 // Test creating rpc response.
-static void testRpcResponse() {
+TEST(UResourceTest, RpcResponse) {
     UResource uResource = UResource::forRpcResponse();
-    assertEquals("rpc", uResource.getName());
-    assertEquals("response", uResource.getInstance());
-    assertTrue(uResource.getMessage().empty());
-    assertEquals(0, uResource.getId().value());
-    assertFalse(uResource.isEmpty());
-    assertTrue(uResource.isResolved());
-    assertTrue(uResource.isLongForm());
-    assertTrue(uResource.isMicroForm());
-    assertTrue(uResource.isRPCMethod());
+    EXPECT_EQ("rpc", uResource.getName());
+    EXPECT_EQ("response", uResource.getInstance());
+    EXPECT_TRUE(uResource.getMessage().empty());
+    EXPECT_EQ(0, uResource.getId().value());
+    EXPECT_FALSE(uResource.isEmpty());
+    EXPECT_TRUE(uResource.isResolved());
+    EXPECT_TRUE(uResource.isLongForm());
+    EXPECT_TRUE(uResource.isMicroForm());
+    EXPECT_TRUE(uResource.isRPCMethod());
 }
 
-Ensure(UResource, all_tests) {
-    testToString();
-    testEmptyResource();
-    testLongFormat();
-    testLongFormatWithoutName();
-    testLongFormatWithoutInstance();
-    testLongFormatWithoutMessage();
-    testLongFormatEmpty();
-    testLongFormatWithBlankValues();
-    testLongFormatWithName();
-    testLongFormatWithNameEmpty();
-    testLongFormatWithNameBlank();
-    testMicroFormat();
-    testMicroFormatWithoutId();
-    testResolvedFormat();
-    testResolvedFormatEmptyName();
-    testResolvedFormatEmptyInstance();
-    testResolvedFormatEmptyMessage();
-    testResolvedFormatEmptyId();
-    testResolvedFormatEmptyValues();
-    testResolvedFormatWithOnlyMessage();
-    testRpcRequestLongFormat();
-    testRpcRequestLongFormatEmptyMethodName();
-    testRpcRequestLongFormatBlankMethodName();
-    testRpcRequestMicroFormat();
-    testRpcRequestMicroFormatWithoutId();
-    testRpcRequestLongAndMicroFormat();
-    testRpcRequestLongAndMicroFormatWithoutId();
-    testRpcRequestLongAndMicroFormatWithoutMethodName();
-    testRpcRequestLongAndMicroFormatWithoutValues();
-    testRpcResponse();
-}
-
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, UResource, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UResourceTest.cpp
+++ b/test/uri/datamodel/UResourceTest.cpp
@@ -25,8 +25,7 @@
 using namespace uprotocol::uri;
 
 // Make sure the toString works.
-TEST(UResourceTest, ToString)
-{
+TEST(UResourceTest, ToString) {
     UResource uResource = UResource::longFormat("door", "front_left", "Door");
     std::string expected("UResource{name='door', instance='front_left', message='Door', id=null, markedResolved=false}");
     EXPECT_EQ(expected, uResource.toString());
@@ -473,8 +472,7 @@ TEST(UResourceTest, RpcResponse) {
     EXPECT_TRUE(uResource.isRPCMethod());
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UUriTest.cpp
+++ b/test/uri/datamodel/UUriTest.cpp
@@ -20,28 +20,13 @@
  */
 #include <iostream>
 #include <string>
-#include <cgreen/cgreen.h>
+#include <gtest/gtest.h>
 #include "UUri.h"
 
-using namespace cgreen;
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(UUri);
-
-BeforeEach(UUri) {
-    // Dummy
-}
-
-AfterEach(UUri) {
-    // Dummy
-}
-
 // Make sure the toString works.
-static void testToString() {
+TEST(UUriTest, ToString) {
     UAuthority uAuthorityLocal = UAuthority::local();
     UAuthority uAuthorityRemote = UAuthority::longRemote("VCU", "MY_VIN");
     UEntity uEntity = UEntity::longFormat("body.access", 1);
@@ -53,7 +38,7 @@ static void testToString() {
                            "uEntity=UEntity{name='body.access', version=1, id=null, markedResolved=false}, "\
                            "uResource=UResource{name='door', instance='front_left', "\
                            "message='null', id=null, markedResolved=false}}";
-    assertEquals(expected, uriLocal.toString());
+    EXPECT_EQ(expected, uriLocal.toString());
 
     auto uriRemote = UUri(uAuthorityRemote, uEntity, uResource);
     expected = "UriPart{uAuthority=UAuthority{device='vcu', domain='my_vin', "\
@@ -61,249 +46,234 @@ static void testToString() {
                "uEntity=UEntity{name='body.access', version=1, id=null, markedResolved=false}, "\
                "uResource=UResource{name='door', instance='front_left', message='null', "\
                "id=null, markedResolved=false}}";
-    assertEquals(expected, uriRemote.toString());
+    EXPECT_EQ(expected, uriRemote.toString());
 
     auto uri = UUri(uAuthorityRemote, uEntity, UResource::empty());
     expected = "UriPart{uAuthority=UAuthority{device='vcu', domain='my_vin', "\
                "address=null, markedRemote=true, markedResolved=false}, "\
                "uEntity=UEntity{name='body.access', version=1, id=null, markedResolved=false}, "\
                "uResource=UResource{name='', instance='null', message='null', id=null, markedResolved=false}}";
-    assertEquals(expected, uri.toString());
+    EXPECT_EQ(expected, uri.toString());
 }
 
 // Test creating full local uri.
-static void testLocalUri() {
+TEST(UUriTest, LocalUri) {
     UAuthority uAuthority = UAuthority::local();
     UEntity uEntity = UEntity::longFormat("body.access");
     UResource uResource = UResource::longFormat("door", "front_left", "");
     UUri uri(uAuthority, uEntity, uResource);
-    assertEquals(uAuthority, uri.getUAuthority());
-    assertEquals(uEntity, uri.getUEntity());
-    assertEquals(uResource, uri.getUResource());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(uAuthority, uri.getUAuthority());
+    EXPECT_EQ(uEntity, uri.getUEntity());
+    EXPECT_EQ(uResource, uri.getUResource());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating full remote uri.
-static void testRemoteUri() {
+TEST(UUriTest, RemoteUri) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_VIN");
     UEntity uEntity = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::longFormat("door", "front_left", "Door");
     UUri uri(uAuthority, uEntity, uResource);
-    assertEquals(uAuthority, uri.getUAuthority());
-    assertEquals(uEntity, uri.getUEntity());
-    assertEquals(uResource, uri.getUResource());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(uAuthority, uri.getUAuthority());
+    EXPECT_EQ(uEntity, uri.getUEntity());
+    EXPECT_EQ(uResource, uri.getUResource());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating rpc response uri.
-static void testRpcResponseUri() {
+TEST(UUriTest, RpcResponseUri) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_VIN");
     UEntity uEntity = UEntity::longFormat("body.access", 1);
     UUri uri = UUri::rpcResponse(uAuthority, uEntity);
-    assertEquals(uAuthority, uri.getUAuthority());
-    assertEquals(uEntity, uri.getUEntity());
-    assertTrue(uri.getUResource().isRPCMethod());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(uAuthority, uri.getUAuthority());
+    EXPECT_EQ(uEntity, uri.getUEntity());
+    EXPECT_TRUE(uri.getUResource().isRPCMethod());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating full uri with resource but no message using the constructor.
-static void testRemoteUriWithoutMessage() {
+TEST(UUriTest, RemoteUriWithoutMessage) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_VIN");
     UEntity uEntity = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::longFormat("door");
     UUri uri(uAuthority, uEntity, "door");
-    assertEquals(uAuthority, uri.getUAuthority());
-    assertEquals(uEntity, uri.getUEntity());
-    assertEquals(uResource, uri.getUResource());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(uAuthority, uri.getUAuthority());
+    EXPECT_EQ(uEntity, uri.getUEntity());
+    EXPECT_EQ(uResource, uri.getUResource());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating a uri with empty authority.
-static void testUriWithEmptyAuthority() {
+TEST(UUriTest, UriWithEmptyAuthority) {
     UEntity uEntity = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::longFormat("door", "front_left", "");
     UUri uri(UAuthority::empty(), uEntity, uResource);
-    assertEquals(UAuthority::empty(), uri.getUAuthority());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(UAuthority::empty(), uri.getUAuthority());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating a uri with empty software entity.
-static void testUriWithEmptyEntity() {
+TEST(UUriTest, UriWithEmptyEntity) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_VIN");
     UResource uResource = UResource::longFormat("door", "front_left", "");
     UUri uri(uAuthority, UEntity::empty(), uResource);
-    assertEquals(UEntity::empty(), uri.getUEntity());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(UEntity::empty(), uri.getUEntity());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 
 // Test creating a uri with empty resource.
-static void testUriWithEmptyResource() {
+TEST(UUriTest, UriWithEmptyResource) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_VIN");
     UEntity uEntity = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::empty();
     UUri uri(uAuthority, uEntity, uResource);
-    assertEquals(UResource::empty(), uri.getUResource());
-    assertFalse(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_EQ(UResource::empty(), uri.getUResource());
+    EXPECT_FALSE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
 }
 
 // Test creating an empty uri using the empty static method.
-static void testEmptyUri() {
+TEST(UUriTest, EmptyUri) {
     UUri uri = UUri::empty();
-    assertTrue(uri.getUAuthority().isLocal());
-    assertTrue(uri.getUEntity().isEmpty());
-    assertTrue(uri.getUResource().isEmpty());
-    assertTrue(uri.isEmpty());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
-    assertFalse(uri.isResolved());
+    EXPECT_TRUE(uri.getUAuthority().isLocal());
+    EXPECT_TRUE(uri.getUEntity().isEmpty());
+    EXPECT_TRUE(uri.getUResource().isEmpty());
+    EXPECT_TRUE(uri.isEmpty());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
     auto uri2 = UUri(UAuthority::empty(), UEntity::empty(), UResource::empty());
-    assertEquals(uri, uri2);
+    EXPECT_EQ(uri, uri2);
 }
 
 // Test isResolved and isLongForm for valid URIs.
-static void testResolvedUri() {
+TEST(UUriTest, ResolvedUri) {
     UUri uri = UUri::empty();
-    assertFalse(uri.isResolved());
-    assertTrue(uri.isLongForm());
-    assertFalse(uri.isMicroForm());
+    EXPECT_FALSE(uri.isResolved());
+    EXPECT_TRUE(uri.isLongForm());
+    EXPECT_FALSE(uri.isMicroForm());
 
     UResource uResource = UResource::forRpcRequest("ExecuteDoorCommand");
     UEntity uEntity = UEntity::longFormat("body.access");
     auto uri2 = UUri(UAuthority::local(), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri2.isResolved());
-    assertTrue(uri2.isLongForm());
-    assertFalse(uri2.isMicroForm());
+    EXPECT_FALSE(uri2.isResolved());
+    EXPECT_TRUE(uri2.isLongForm());
+    EXPECT_FALSE(uri2.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri3 = UUri(UAuthority::local(), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri3.isResolved());
-    assertTrue(uri3.isLongForm());
-    assertFalse(uri3.isMicroForm());
+    EXPECT_FALSE(uri3.isResolved());
+    EXPECT_TRUE(uri3.isLongForm());
+    EXPECT_FALSE(uri3.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri4 = UUri(UAuthority::local(), UEntity::resolvedFormat("body.access", std::nullopt, 2), uResource);
-    assertTrue(uri4.isResolved());
-    assertTrue(uri4.isLongForm());
-    assertFalse(uri3.isMicroForm());
+    EXPECT_TRUE(uri4.isResolved());
+    EXPECT_TRUE(uri4.isLongForm());
+    EXPECT_FALSE(uri3.isMicroForm());
 
     uResource = UResource::forRpcRequest("ExecuteDoorCommand");
     auto uri11 = UUri(UAuthority::local(), UEntity::resolvedFormat("body.access", std::nullopt, 2), uResource);
-    assertFalse(uri11.isResolved());
-    assertTrue(uri11.isLongForm());
-    assertFalse(uri11.isMicroForm());
+    EXPECT_FALSE(uri11.isResolved());
+    EXPECT_TRUE(uri11.isLongForm());
+    EXPECT_FALSE(uri11.isMicroForm());
 
     uResource = UResource::forRpcRequest("ExecuteDoorCommand");
     auto uri5 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri5.isResolved());
-    assertTrue(uri5.isLongForm());
-    assertFalse(uri5.isMicroForm());
+    EXPECT_FALSE(uri5.isResolved());
+    EXPECT_TRUE(uri5.isLongForm());
+    EXPECT_FALSE(uri5.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri6 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri6.isResolved());
-    assertTrue(uri6.isLongForm());
-    assertFalse(uri6.isMicroForm());
+    EXPECT_FALSE(uri6.isResolved());
+    EXPECT_TRUE(uri6.isLongForm());
+    EXPECT_FALSE(uri6.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri7 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri7.isResolved());
-    assertTrue(uri7.isLongForm());
-    assertFalse(uri7.isMicroForm());
+    EXPECT_FALSE(uri7.isResolved());
+    EXPECT_TRUE(uri7.isLongForm());
+    EXPECT_FALSE(uri7.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri14 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::resolvedFormat("body.access", 1, 2), uResource);
-    assertFalse(uri14.isResolved());
-    assertTrue(uri14.isLongForm());
-    assertFalse(uri14.isMicroForm());
+    EXPECT_FALSE(uri14.isResolved());
+    EXPECT_TRUE(uri14.isLongForm());
+    EXPECT_FALSE(uri14.isMicroForm());
 
     uResource = UResource::forRpcRequest("ExecuteDoorCommand");
     auto uri8 = UUri(UAuthority::resolvedRemote("vcu", "vin", "192.168.1.100"), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri8.isResolved());
-    assertTrue(uri8.isLongForm());
-    assertFalse(uri8.isMicroForm());
+    EXPECT_FALSE(uri8.isResolved());
+    EXPECT_TRUE(uri8.isLongForm());
+    EXPECT_FALSE(uri8.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri9 = UUri(UAuthority::resolvedRemote("vcu", "vin", "192.168.1.100"), UEntity::longFormat("body.access"), uResource);
-    assertFalse(uri9.isResolved());
-    assertTrue(uri9.isLongForm());
-    assertFalse(uri9.isMicroForm());
+    EXPECT_FALSE(uri9.isResolved());
+    EXPECT_TRUE(uri9.isLongForm());
+    EXPECT_FALSE(uri9.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri10 = UUri(UAuthority::resolvedRemote("vcu", "vin", "192.168.1.100"), UEntity::resolvedFormat("body.access", std::nullopt, 2), uResource);
-    assertTrue(uri10.isResolved());
-    assertTrue(uri10.isLongForm());
-    assertTrue(uri10.isMicroForm());
+    EXPECT_TRUE(uri10.isResolved());
+    EXPECT_TRUE(uri10.isLongForm());
+    EXPECT_TRUE(uri10.isMicroForm());
 
     uResource = UResource::microFormat(2);
     auto uri12 = UUri(UAuthority::resolvedRemote("vcu", "vin", "192.168.1.100"), UEntity::resolvedFormat("body.access", std::nullopt, 2), uResource);
-    assertFalse(uri12.isResolved());
-    assertFalse(uri12.isLongForm());
-    assertTrue(uri12.isMicroForm());
+    EXPECT_FALSE(uri12.isResolved());
+    EXPECT_FALSE(uri12.isLongForm());
+    EXPECT_TRUE(uri12.isMicroForm());
 
     uResource = UResource::microFormat(2);
     auto uri19 = UUri(UAuthority::microRemote("192.168.1.100"), UEntity::resolvedFormat("body.access", std::nullopt, 2), uResource);
-    assertFalse(uri19.isResolved());
-    assertFalse(uri19.isLongForm());
-    assertTrue(uri19.isMicroForm());
+    EXPECT_FALSE(uri19.isResolved());
+    EXPECT_FALSE(uri19.isLongForm());
+    EXPECT_TRUE(uri19.isMicroForm());
 
     uResource = UResource::microFormat(2);
     auto uri16 = UUri(UAuthority::local(), UEntity::microFormat((short)2, 1), uResource);
-    assertFalse(uri16.isResolved());
-    assertFalse(uri16.isLongForm());
-    assertTrue(uri16.isMicroForm());
+    EXPECT_FALSE(uri16.isResolved());
+    EXPECT_FALSE(uri16.isLongForm());
+    EXPECT_TRUE(uri16.isMicroForm());
 
     uResource = UResource::resolvedFormat("door", "front_left", "Door", 1);
     auto uri17 = UUri(UAuthority::resolvedRemote("vcu", "vin", "192.168.1.100"), UEntity::microFormat(2, 1), uResource);
-    assertFalse(uri17.isResolved());
-    assertFalse(uri17.isLongForm());
-    assertTrue(uri17.isMicroForm());
+    EXPECT_FALSE(uri17.isResolved());
+    EXPECT_FALSE(uri17.isLongForm());
+    EXPECT_TRUE(uri17.isMicroForm());
 
     uResource = UResource::microFormat(2);
     auto uri18 = UUri(UAuthority::local(), UEntity::microFormat(2, 1), uResource);
-    assertFalse(uri18.isResolved());
-    assertFalse(uri18.isLongForm());
-    assertTrue(uri18.isMicroForm());
+    EXPECT_FALSE(uri18.isResolved());
+    EXPECT_FALSE(uri18.isLongForm());
+    EXPECT_TRUE(uri18.isMicroForm());
 }
 
-Ensure(UUri, all_tests) {
-    testToString();
-    testLocalUri();
-    testRemoteUri();
-    testRpcResponseUri();
-    testRemoteUriWithoutMessage();
-    testUriWithEmptyAuthority();
-    testUriWithEmptyEntity();
-    testUriWithEmptyResource();
-    testEmptyUri();
-    testResolvedUri();
-}
-
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, UUri, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/datamodel/UUriTest.cpp
+++ b/test/uri/datamodel/UUriTest.cpp
@@ -272,8 +272,7 @@ TEST(UUriTest, ResolvedUri) {
     EXPECT_TRUE(uri18.isMicroForm());
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/serializer/LongUriSerializerTest.cpp
+++ b/test/uri/serializer/LongUriSerializerTest.cpp
@@ -19,772 +19,692 @@
  * under the License.
  */
 #include <string>
-#include <cgreen/cgreen.h>
+#include <gtest/gtest.h>
 #include "LongUriSerializer.h"
 #include "UUri.h"
 #include "UAuthority.h"
 #include "UEntity.h"
 #include "UResource.h"
 
-using namespace cgreen;
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(LongUriSerializer);
-
-BeforeEach(LongUriSerializer) {
-    // Dummy
-}
-
-AfterEach(LongUriSerializer) {
-    // Dummy
-}
-
 // Test using the serializers.
-static void test_using_the_serializers() {
+TEST(LongUriSerializerTest, UsingTheSerializers) {
     auto uURi = UUri(UAuthority::local(),
                     UEntity::longFormat("body.access"),
                     UResource::forRpcRequest("door"));
-    auto uri = LongUriSerializer::serialize(uURi);
-    assertEquals("/body.access//rpc.door", uri);
-    auto uUri2 = LongUriSerializer::deserialize(uri);
-    assertEquals(uURi, uUri2);
+    auto uri = LongUriSerializer::getInstance().serialize(uURi);
+    EXPECT_EQ("/body.access//rpc.door", uri);
+    auto uUri2 = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uURi, uUri2);
 }
 
 // Test parse uProtocol uri when is empty string.
-static void test_parse_protocol_uri_when_is_empty_string() {
+TEST(LongUriSerializerTest, ParseProtocolUriWhenIsEmptyString) {
     std::string uri;
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isResolved());
-    assertTrue(uUri.isLongForm());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isResolved());
+    EXPECT_TRUE(uUri.isLongForm());
 }
 
 // Test parse uProtocol uri with schema and slash.
-static void test_parse_protocol_uri_with_schema_and_slash() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAndSlash) {
     std::string uri = "/";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertTrue(uUri.isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_TRUE(uUri.isEmpty());
 
-    auto uri2 = LongUriSerializer::serialize(UUri::empty());
-    assertTrue(uri2.empty());
+    auto uri2 = LongUriSerializer::getInstance().serialize(UUri::empty());
+    EXPECT_TRUE(uri2.empty());
 }
 
 // Test parse uProtocol uri with schema and double slash.
-static void test_parse_protocol_uri_with_schema_and_double_slash() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAndDoubleSlash) {
     std::string uri = "//";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertFalse(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUAuthority().isMarkedRemote());
-    assertTrue(uUri.isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_TRUE(uUri.isEmpty());
 }
 
 // Test parse uProtocol uri with schema and 3 slash and something.
-static void test_parse_protocol_uri_with_schema_and_3_slash_and_something() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd3SlashAndSomething) {
     std::string uri = "///body.access";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertFalse(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertFalse(uUri.getUEntity().getVersion().has_value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_FALSE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with schema and 4 slash and something.
-static void test_parse_protocol_uri_with_schema_and_4_slash_and_something() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd4SlashAndSomething) {
     std::string uri = "////body.access";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertFalse(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUAuthority().isMarkedRemote());
-    assertTrue(uUri.getUEntity().getName().empty());
-    assertFalse(uUri.getUEntity().getVersion().has_value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_TRUE(uUri.getUEntity().getName().empty());
+    EXPECT_FALSE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with schema and 5 slash and something.
-static void test_parse_protocol_uri_with_schema_and_5_slash_and_something() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd5SlashAndSomething) {
     std::string uri = "/////body.access";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertFalse(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUAuthority().isMarkedRemote());
-    assertTrue(uUri.getUEntity().isEmpty());
-    assertEquals("body", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("access", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_TRUE(uUri.getUEntity().isEmpty());
+    EXPECT_EQ("body", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("access", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with schema and 6 slash and something.
-static void test_parse_protocol_uri_with_schema_and_6_slash_and_something() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd6SlashAndSomething) {
     std::string uri = "//////body.access";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertFalse(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUAuthority().isMarkedRemote());
-    assertTrue(uUri.isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_TRUE(uUri.isEmpty());
 }
 
 // Test parse uProtocol uri with local service no version.
-static void test_parse_protocol_uri_with_local_service_no_version() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersion) {
     std::string uri = "/body.access/";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with local service with version.
-static void test_parse_protocol_uri_with_local_service_with_version() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceWithVersion) {
     std::string uri = "/body.access/1";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with local service no version with resource name only.
-static void
-test_parse_protocol_uri_with_local_service_no_version_with_resource_name_only() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersionWithResourceNameOnly) {
     std::string uri = "/body.access//door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertTrue(uUri.getUResource().getInstance().empty());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_TRUE(uUri.getUResource().getInstance().empty());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with local service with version with resource name only.
-static void
-test_parse_protocol_uri_with_local_service_with_version_with_resource_name_only() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithLocalServiceWithVersionWithResourceNameOnly) {
     std::string uri = "/body.access/1/door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertTrue(uUri.getUResource().getInstance().empty());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_TRUE(uUri.getUResource().getInstance().empty());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with local service no version with resource and instance only.
-static void
-test_parse_protocol_uri_with_local_service_no_version_with_resource_with_instance() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithLocalServiceNoVersionWithResourceWithInstance) {
     std::string uri = "/body.access//door.front_left";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertFalse(uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_FALSE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with local service with version with resource and instance only.
-static void
-test_parse_protocol_uri_with_local_service_with_version_with_resource_with_message() {
+TEST(LongUriSerializerTest,
+Parse_protocol_uri_with_local_service_with_version_with_resource_with_message) {
     std::string uri = "/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with local service no version with resource with instance and message.
-static void
-test_parse_protocol_uri_with_local_service_no_version_with_resource_with_instance_and_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithLocalServiceNoVersionWithResourceWithinStanceAndMessage) {
     std::string uri = "/body.access//door.front_left#Door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertFalse(uUri.getUResource().getMessage().empty());
-    assertEquals("Door", uUri.getUResource().getMessage());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_FALSE(uUri.getUResource().getMessage().empty());
+    EXPECT_EQ("Door", uUri.getUResource().getMessage());
 }
 
 // Test parse uProtocol uri with local service with version with resource with instance and message.
-static void
-test_parse_protocol_uri_with_local_service_with_version_with_resource_with_instance_and_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithLocalServiceWithVersionWithResourceWithInstanceAndMessage) {
     std::string uri = "/body.access/1/door.front_left#Door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertFalse(uUri.getUResource().getMessage().empty());
-    assertEquals("Door", uUri.getUResource().getMessage());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_FALSE(uUri.getUResource().getMessage().empty());
+    EXPECT_EQ("Door", uUri.getUResource().getMessage());
 }
 
 // Test parse uProtocol RPC uri with local service no version.
-static void test_parse_protocol_rpc_uri_with_local_service_no_version() {
+TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceNoVersion) {
     std::string uri = "/petapp//rpc.response";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("petapp", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("rpc", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("response", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("petapp", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("rpc", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("response", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol RPC uri with local service with version.
-static void test_parse_protocol_rpc_uri_with_local_service_with_version() {
+TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceWithVersion) {
     std::string uri = "/petapp/1/rpc.response";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertFalse(uUri.getUAuthority().isMarkedRemote());
-    assertEquals("petapp", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("rpc", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("response", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
+    EXPECT_EQ("petapp", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("rpc", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("response", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with microRemote service only device no domain.
-static void
-test_parse_protocol_uri_with_remote_service_only_device_no_domain() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceOnlyDeviceNoDomain) {
     std::string uri = "//VCU";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertTrue(uUri.getUAuthority().getDomain().empty());
-    assertTrue(uUri.getUEntity().isEmpty());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_TRUE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_TRUE(uUri.getUEntity().isEmpty());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with microRemote service only device and domain.
-static void
-test_parse_protocol_uri_with_remote_service_only_device_and_domain() {
+TEST(LongUriSerializerTest,
+Parse_protocol_uri_with_remote_service_only_device_and_domain) {
     std::string uri = "//VCU.MY_CAR_VIN";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertTrue(uUri.getUEntity().isEmpty());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_TRUE(uUri.getUEntity().isEmpty());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with microRemote service no version.
-static void test_parse_protocol_uri_with_remote_service_no_version() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceNoVersion) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with microRemote service with version.
-static void test_parse_protocol_uri_with_remote_service_with_version() {
+TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceWithVersion) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertTrue(uUri.getUResource().isEmpty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_TRUE(uUri.getUResource().isEmpty());
 }
 
 // Test parse uProtocol uri with microRemote service no version with resource name only.
-static void
-test_parse_protocol_uri_with_remote_service_no_version_with_resource_name_only() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceNoVersionWithResourceNameOnly) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertTrue(uUri.getUResource().getInstance().empty());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_TRUE(uUri.getUResource().getInstance().empty());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with microRemote service with version with resource name only.
-static void
-test_parse_protocol_uri_with_remote_service_with_version_with_resource_name_only() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceWithVersionWithResourceNameOnly) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertTrue(uUri.getUResource().getInstance().empty());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_TRUE(uUri.getUResource().getInstance().empty());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with microRemote service no version with resource and instance no message.
-static void
-test_parse_protocol_uri_with_remote_service_no_version_with_resource_and_instance_no_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceNoMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door.front_left";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with microRemote service with version with resource and instance no message.
-static void
-test_parse_protocol_uri_with_remote_service_with_version_with_resource_and_instance_no_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceNoMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol uri with microRemote service no version with resource and instance and message.
-static void
-test_parse_protocol_uri_with_remote_service_no_version_with_resource_and_instance_and_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceAndMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door.front_left#Door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertFalse(uUri.getUResource().getMessage().empty());
-    assertEquals("Door", uUri.getUResource().getMessage());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_FALSE(uUri.getUResource().getMessage().empty());
+    EXPECT_EQ("Door", uUri.getUResource().getMessage());
 }
 
 // Test parse uProtocol uri with microRemote service with version with resource and instance and message.
-static void
-test_parse_protocol_uri_with_remote_service_with_version_with_resource_and_instance_and_message() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceAndMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door.front_left#Door";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("my_car_vin", uUri.getUAuthority().getDomain());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertFalse(uUri.getUResource().getMessage().empty());
-    assertEquals("Door", uUri.getUResource().getMessage());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("my_car_vin", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_FALSE(uUri.getUResource().getMessage().empty());
+    EXPECT_EQ("Door", uUri.getUResource().getMessage());
 }
 
 // Test parse uProtocol uri with microRemote service with version with resource with
 // message when there is only device, no domain.
-static void
-test_parse_protocol_uri_with_remote_service_with_version_with_resource_with_message_device_no_domain() {
+TEST(LongUriSerializerTest,
+ParseProtocolUriWithRemoteServiceWithVersionWithResourceWithMessageDeviceNoDomain) {
     std::string uri = "//VCU/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("vcu", uUri.getUAuthority().getDevice());
-    assertTrue(uUri.getUAuthority().getDomain().empty());
-    assertEquals("body.access", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("door", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("front_left", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
+    EXPECT_TRUE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("body.access", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("door", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("front_left", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol RPC uri with microRemote service no version.
-static void test_parse_protocol_rpc_uri_with_remote_service_no_version() {
+TEST(LongUriSerializerTest,
+ParseProtocolRpcUriWithRemoteServiceNoVersion) {
     std::string uri = "//bo.azure/petapp//rpc.response";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("bo", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("azure", uUri.getUAuthority().getDomain());
-    assertEquals("petapp", uUri.getUEntity().getName());
-    assertTrue(!uUri.getUEntity().getVersion().has_value());
-    assertEquals("rpc", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("response", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("bo", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("azure", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("petapp", uUri.getUEntity().getName());
+    EXPECT_TRUE(!uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ("rpc", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("response", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test parse uProtocol RPC uri with microRemote service with version.
-static void test_parse_protocol_rpc_uri_with_remote_service_with_version() {
+TEST(LongUriSerializerTest,
+ParseProtocolRpcUriWithRemoteServiceWithVersion){
     std::string uri = "//bo.azure/petapp/1/rpc.response";
-    auto uUri = LongUriSerializer::deserialize(uri);
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertFalse(uUri.getUAuthority().getDevice().empty());
-    assertEquals("bo", uUri.getUAuthority().getDevice());
-    assertFalse(uUri.getUAuthority().getDomain().empty());
-    assertEquals("azure", uUri.getUAuthority().getDomain());
-    assertEquals("petapp", uUri.getUEntity().getName());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(1, uUri.getUEntity().getVersion().value());
-    assertEquals("rpc", uUri.getUResource().getName());
-    assertFalse(uUri.getUResource().getInstance().empty());
-    assertEquals("response", uUri.getUResource().getInstance());
-    assertTrue(uUri.getUResource().getMessage().empty());
+    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
+    EXPECT_EQ("bo", uUri.getUAuthority().getDevice());
+    EXPECT_FALSE(uUri.getUAuthority().getDomain().empty());
+    EXPECT_EQ("azure", uUri.getUAuthority().getDomain());
+    EXPECT_EQ("petapp", uUri.getUEntity().getName());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(1, uUri.getUEntity().getVersion().value());
+    EXPECT_EQ("rpc", uUri.getUResource().getName());
+    EXPECT_FALSE(uUri.getUResource().getInstance().empty());
+    EXPECT_EQ("response", uUri.getUResource().getInstance());
+    EXPECT_TRUE(uUri.getUResource().getMessage().empty());
 }
 
 // Test Create a uProtocol URI from an empty URI Object.
-static void test_build_protocol_uri_from_uri_when_uri_isEmpty() {
+TEST(LongUriSerializerTest, BuildProtocolUriFromUriWhenUriIsEmpty) {
     auto uUri = UUri::empty();
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI object with an empty UEntity.
-static void test_build_protocol_uri_from_uri_when_uri_has_empty_use() {
+TEST(LongUriSerializerTest, BuildProtocolUriFromUriWhenUriHasEmptyUse) {
     auto use = UEntity::empty();
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority with service no version.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersion) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access/", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access/", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority with service and version.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersion) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access/1", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access/1", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service no version with resource.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResource) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access//door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access//door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service and version with resource.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResource) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access/1/door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access/1/door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service no version with resource with instance no message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource_with_instance_no_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access//door.front_left", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access//door.front_left", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service and version with resource with instance no message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource_with_instance_no_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri( UAuthority::local(), use, UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access/1/door.front_left", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access/1/door.front_left", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service no version with resource with instance and message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource_with_instance_with_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResourceWithInstanceWithMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access//door.front_left#Door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access//door.front_left#Door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a local authority
 // with service and version with resource with instance and message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource_with_instance_with_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResourceWithInstanceWithMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("/body.access/1/door.front_left#Door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("/body.access/1/door.front_left#Door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority with service no version.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version() {
+TEST(LongUriSerializerTest,
+Build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority no
 // device with domain with service no version.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_no_device_with_domain_with_service_no_version() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityNoDeviceWithDomainWithServiceNoVersion) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//my_car_vin/body.access/", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//my_car_vin/body.access/", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service and version.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersion) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/1", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/1", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service and version with resource.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResource) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service no version with resource.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResource) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access//door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access//door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service and version with resource with instance no message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource_with_instance_no_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                      UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/1/door.front_left", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/1/door.front_left", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service no version with resource with instance no message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource_with_instance_no_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                     UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access//door.front_left", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access//door.front_left", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a microRemote authority
 // with service and version with resource with instance and message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource_with_instance_and_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResourceWithInstanceAndMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/1/door.front_left#Door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/1/door.front_left#Door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from an URI Object with a longRemote authority
 // with service no version with resource with instance and message.
-static void
-test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource_with_instance_and_message() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResourceWithInstanceAndMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                       UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access//door.front_left#Door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access//door.front_left#Door", uProtocolUri);
 }
 
 // Test Create a uProtocol URI for the source part of an RPC request, where the
 // source is local.
-static void
-test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_local() {
+TEST(LongUriSerializerTest, BuildProtocolUriForSourcePartOfRpcRequestWhereSourceIsLocal) {
     UAuthority uAuthority = UAuthority::local();
     auto use = UEntity::longFormat("petapp", 1);
-    std::string uProtocolUri = LongUriSerializer::serialize(UUri::rpcResponse(uAuthority, use));
-    assertEquals("/petapp/1/rpc.response", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(UUri::rpcResponse(uAuthority, use));
+    EXPECT_EQ("/petapp/1/rpc.response", uProtocolUri);
 }
 
 // Test Create a uProtocol URI for the source part of an RPC request, where the
 // source is microRemote.
-static void
-test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_remote() {
+TEST(LongUriSerializerTest, BuildProtocolUriForSourcePartOfRpcRequestWhereSourceIsRemote) {
     UAuthority uAuthority = UAuthority::longRemote("bo", "azure");
     auto use = UEntity::longFormat("petapp");
-    std::string uProtocolUri = LongUriSerializer::serialize(UUri::rpcResponse(uAuthority, use));
-    assertEquals("//bo.azure/petapp//rpc.response", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(UUri::rpcResponse(uAuthority, use));
+    EXPECT_EQ("//bo.azure/petapp//rpc.response", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from parts that are null.
-static void test_build_protocol_uri_from_parts_when_they_are_null() {
+TEST(LongUriSerializerTest, BuildProtocolUriFromPartsWhenTheyAreNull) {
     UAuthority uAuthority;
     UEntity uSoftwareEntity;
     UResource uResource;
     auto uUri = UUri(uAuthority, uSoftwareEntity, uResource);
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("", uProtocolUri);
 }
 
 // Test Create a uProtocol URI from the parts of URI Object with a microRemote
 // authority with service and version with resource.
-static void
-test_build_protocol_uri_from_uri_parts_when_uri_has_remote_authority_service_and_version_with_resource() {
+TEST(LongUriSerializerTest,
+BuildProtocolUriFromUriPartsWhenUriHasRemoteAuthorityServiceAndVersionWithResource) {
     UAuthority uAuthority = UAuthority::longRemote("VCU", "MY_CAR_VIN");
     auto use = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::longFormat("door");
     auto uUri = UUri(uAuthority, use, uResource);
-    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
-    assertEquals("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
+    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
 }
 
-Ensure(LongUriSerializer, all_tests) {
-    test_using_the_serializers();
-
-    test_parse_protocol_uri_when_is_empty_string();
-    test_parse_protocol_uri_with_schema_and_slash();
-    test_parse_protocol_uri_with_schema_and_double_slash();
-    test_parse_protocol_uri_with_schema_and_3_slash_and_something();
-    test_parse_protocol_uri_with_schema_and_4_slash_and_something();
-    test_parse_protocol_uri_with_schema_and_5_slash_and_something();
-    test_parse_protocol_uri_with_schema_and_6_slash_and_something();
-
-    test_parse_protocol_uri_with_local_service_no_version();
-    test_parse_protocol_uri_with_local_service_with_version();
-    test_parse_protocol_uri_with_local_service_no_version_with_resource_name_only();
-    test_parse_protocol_uri_with_local_service_with_version_with_resource_name_only();
-    test_parse_protocol_uri_with_local_service_no_version_with_resource_with_instance();
-    test_parse_protocol_uri_with_local_service_with_version_with_resource_with_message();
-    test_parse_protocol_uri_with_local_service_no_version_with_resource_with_instance_and_message();
-    test_parse_protocol_uri_with_local_service_with_version_with_resource_with_instance_and_message();
-
-    test_parse_protocol_rpc_uri_with_local_service_no_version();
-    test_parse_protocol_rpc_uri_with_local_service_with_version();
-
-    test_parse_protocol_uri_with_remote_service_only_device_no_domain();
-    test_parse_protocol_uri_with_remote_service_only_device_and_domain();
-
-    test_parse_protocol_uri_with_remote_service_no_version();
-    test_parse_protocol_uri_with_remote_service_with_version();
-    test_parse_protocol_uri_with_remote_service_no_version_with_resource_name_only();
-    test_parse_protocol_uri_with_remote_service_with_version_with_resource_name_only();
-    test_parse_protocol_uri_with_remote_service_no_version_with_resource_and_instance_no_message();
-    test_parse_protocol_uri_with_remote_service_with_version_with_resource_and_instance_no_message();
-    test_parse_protocol_uri_with_remote_service_no_version_with_resource_and_instance_and_message();
-    test_parse_protocol_uri_with_remote_service_with_version_with_resource_and_instance_and_message();
-    test_parse_protocol_uri_with_remote_service_with_version_with_resource_with_message_device_no_domain();
-    test_parse_protocol_rpc_uri_with_remote_service_no_version();
-    test_parse_protocol_rpc_uri_with_remote_service_with_version();
-    test_build_protocol_uri_from_uri_when_uri_isEmpty();
-    test_build_protocol_uri_from_uri_when_uri_has_empty_use();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource_with_instance_no_message();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource_with_instance_no_message();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_no_version_with_resource_with_instance_with_message();
-    test_build_protocol_uri_from_uri_when_uri_has_local_authority_service_and_version_with_resource_with_instance_with_message();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_no_device_with_domain_with_service_no_version();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource_with_instance_no_message();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource_with_instance_no_message();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_and_version_with_resource_with_instance_and_message();
-    test_build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version_with_resource_with_instance_and_message();
-    test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_local();
-    test_build_protocol_uri_for_source_part_of_rpc_request_where_source_is_remote();
-    test_build_protocol_uri_from_parts_when_they_are_null();
-    test_build_protocol_uri_from_uri_parts_when_uri_has_remote_authority_service_and_version_with_resource();
-}
-
-int main(int argc, const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, LongUriSerializer, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/serializer/LongUriSerializerTest.cpp
+++ b/test/uri/serializer/LongUriSerializerTest.cpp
@@ -462,7 +462,7 @@ ParseProtocolRpcUriWithRemoteServiceNoVersion) {
 
 // Test parse uProtocol RPC uri with microRemote service with version.
 TEST(LongUriSerializerTest,
-ParseProtocolRpcUriWithRemoteServiceWithVersion){
+ParseProtocolRpcUriWithRemoteServiceWithVersion) {
     std::string uri = "//bo.azure/petapp/1/rpc.response";
     auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
@@ -704,8 +704,7 @@ BuildProtocolUriFromUriPartsWhenUriHasRemoteAuthorityServiceAndVersionWithResour
     EXPECT_EQ("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/serializer/LongUriSerializerTest.cpp
+++ b/test/uri/serializer/LongUriSerializerTest.cpp
@@ -25,6 +25,7 @@
 #include "UAuthority.h"
 #include "UEntity.h"
 #include "UResource.h"
+#include "IpAddress.h"
 
 using namespace uprotocol::uri;
 
@@ -33,16 +34,16 @@ TEST(LongUriSerializerTest, UsingTheSerializers) {
     auto uURi = UUri(UAuthority::local(),
                     UEntity::longFormat("body.access"),
                     UResource::forRpcRequest("door"));
-    auto uri = LongUriSerializer::getInstance().serialize(uURi);
+    auto uri = LongUriSerializer::serialize(uURi);
     EXPECT_EQ("/body.access//rpc.door", uri);
-    auto uUri2 = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri2 = LongUriSerializer::deserialize(uri);
     EXPECT_EQ(uURi, uUri2);
 }
 
 // Test parse uProtocol uri when is empty string.
 TEST(LongUriSerializerTest, ParseProtocolUriWhenIsEmptyString) {
     std::string uri;
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isResolved());
     EXPECT_TRUE(uUri.isLongForm());
@@ -51,19 +52,19 @@ TEST(LongUriSerializerTest, ParseProtocolUriWhenIsEmptyString) {
 // Test parse uProtocol uri with schema and slash.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAndSlash) {
     std::string uri = "/";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_TRUE(uUri.isEmpty());
 
-    auto uri2 = LongUriSerializer::getInstance().serialize(UUri::empty());
+    auto uri2 = LongUriSerializer::serialize(UUri::empty());
     EXPECT_TRUE(uri2.empty());
 }
 
 // Test parse uProtocol uri with schema and double slash.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAndDoubleSlash) {
     std::string uri = "//";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.getUAuthority().isLocal());
     EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_TRUE(uUri.isEmpty());
@@ -72,7 +73,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAndDoubleSlash) {
 // Test parse uProtocol uri with schema and 3 slash and something.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd3SlashAndSomething) {
     std::string uri = "///body.access";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.getUAuthority().isLocal());
     EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -83,7 +84,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd3SlashAndSomething) {
 // Test parse uProtocol uri with schema and 4 slash and something.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd4SlashAndSomething) {
     std::string uri = "////body.access";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.getUAuthority().isLocal());
     EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_TRUE(uUri.getUEntity().getName().empty());
@@ -94,7 +95,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd4SlashAndSomething) {
 // Test parse uProtocol uri with schema and 5 slash and something.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd5SlashAndSomething) {
     std::string uri = "/////body.access";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.getUAuthority().isLocal());
     EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_TRUE(uUri.getUEntity().isEmpty());
@@ -107,7 +108,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd5SlashAndSomething) {
 // Test parse uProtocol uri with schema and 6 slash and something.
 TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd6SlashAndSomething) {
     std::string uri = "//////body.access";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.getUAuthority().isLocal());
     EXPECT_TRUE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_TRUE(uUri.isEmpty());
@@ -116,7 +117,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithSchemaAnd6SlashAndSomething) {
 // Test parse uProtocol uri with local service no version.
 TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersion) {
     std::string uri = "/body.access/";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -127,7 +128,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersion) {
 // Test parse uProtocol uri with local service with version.
 TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceWithVersion) {
     std::string uri = "/body.access/1";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -139,7 +140,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceWithVersion) {
 // Test parse uProtocol uri with local service no version with resource name only.
 TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersionWithResourceNameOnly) {
     std::string uri = "/body.access//door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -153,7 +154,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithLocalServiceNoVersionWithResourc
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithLocalServiceWithVersionWithResourceNameOnly) {
     std::string uri = "/body.access/1/door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -168,7 +169,7 @@ ParseProtocolUriWithLocalServiceWithVersionWithResourceNameOnly) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithLocalServiceNoVersionWithResourceWithInstance) {
     std::string uri = "/body.access//door.front_left";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -183,7 +184,7 @@ ParseProtocolUriWithLocalServiceNoVersionWithResourceWithInstance) {
 TEST(LongUriSerializerTest,
 Parse_protocol_uri_with_local_service_with_version_with_resource_with_message) {
     std::string uri = "/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -199,7 +200,7 @@ Parse_protocol_uri_with_local_service_with_version_with_resource_with_message) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithLocalServiceNoVersionWithResourceWithinStanceAndMessage) {
     std::string uri = "/body.access//door.front_left#Door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -215,7 +216,7 @@ ParseProtocolUriWithLocalServiceNoVersionWithResourceWithinStanceAndMessage) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithLocalServiceWithVersionWithResourceWithInstanceAndMessage) {
     std::string uri = "/body.access/1/door.front_left#Door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("body.access", uUri.getUEntity().getName());
@@ -231,7 +232,7 @@ ParseProtocolUriWithLocalServiceWithVersionWithResourceWithInstanceAndMessage) {
 // Test parse uProtocol RPC uri with local service no version.
 TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceNoVersion) {
     std::string uri = "/petapp//rpc.response";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("petapp", uUri.getUEntity().getName());
@@ -245,7 +246,7 @@ TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceNoVersion) {
 // Test parse uProtocol RPC uri with local service with version.
 TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceWithVersion) {
     std::string uri = "/petapp/1/rpc.response";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isLocal());
     EXPECT_FALSE(uUri.getUAuthority().isMarkedRemote());
     EXPECT_EQ("petapp", uUri.getUEntity().getName());
@@ -261,7 +262,7 @@ TEST(LongUriSerializerTest, ParseProtocolRpcUriWithLocalServiceWithVersion) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceOnlyDeviceNoDomain) {
     std::string uri = "//VCU";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
     EXPECT_TRUE(uUri.getUAuthority().getDomain().empty());
     EXPECT_TRUE(uUri.getUEntity().isEmpty());
@@ -272,7 +273,7 @@ ParseProtocolUriWithRemoteServiceOnlyDeviceNoDomain) {
 TEST(LongUriSerializerTest,
 Parse_protocol_uri_with_remote_service_only_device_and_domain) {
     std::string uri = "//VCU.MY_CAR_VIN";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -285,7 +286,7 @@ Parse_protocol_uri_with_remote_service_only_device_and_domain) {
 // Test parse uProtocol uri with microRemote service no version.
 TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceNoVersion) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -299,7 +300,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceNoVersion) {
 // Test parse uProtocol uri with microRemote service with version.
 TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceWithVersion) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -315,7 +316,7 @@ TEST(LongUriSerializerTest, ParseProtocolUriWithRemoteServiceWithVersion) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceNoVersionWithResourceNameOnly) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -332,7 +333,7 @@ ParseProtocolUriWithRemoteServiceNoVersionWithResourceNameOnly) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceWithVersionWithResourceNameOnly) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -350,7 +351,7 @@ ParseProtocolUriWithRemoteServiceWithVersionWithResourceNameOnly) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceNoMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door.front_left";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -368,7 +369,7 @@ ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceNoMessage) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceNoMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -387,7 +388,7 @@ ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceNoMessage) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceAndMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access//door.front_left#Door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -406,7 +407,7 @@ ParseProtocolUriWithRemoteServiceNoVersionWithResourceAndInstanceAndMessage) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceAndMessage) {
     std::string uri = "//VCU.MY_CAR_VIN/body.access/1/door.front_left#Door";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -427,7 +428,7 @@ ParseProtocolUriWithRemoteServiceWithVersionWithResourceAndInstanceAndMessage) {
 TEST(LongUriSerializerTest,
 ParseProtocolUriWithRemoteServiceWithVersionWithResourceWithMessageDeviceNoDomain) {
     std::string uri = "//VCU/body.access/1/door.front_left";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("vcu", uUri.getUAuthority().getDevice());
@@ -445,7 +446,7 @@ ParseProtocolUriWithRemoteServiceWithVersionWithResourceWithMessageDeviceNoDomai
 TEST(LongUriSerializerTest,
 ParseProtocolRpcUriWithRemoteServiceNoVersion) {
     std::string uri = "//bo.azure/petapp//rpc.response";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("bo", uUri.getUAuthority().getDevice());
@@ -463,7 +464,7 @@ ParseProtocolRpcUriWithRemoteServiceNoVersion) {
 TEST(LongUriSerializerTest,
 ParseProtocolRpcUriWithRemoteServiceWithVersion){
     std::string uri = "//bo.azure/petapp/1/rpc.response";
-    auto uUri = LongUriSerializer::getInstance().deserialize(uri);
+    auto uUri = LongUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.getUAuthority().isRemote());
     EXPECT_FALSE(uUri.getUAuthority().getDevice().empty());
     EXPECT_EQ("bo", uUri.getUAuthority().getDevice());
@@ -481,7 +482,7 @@ ParseProtocolRpcUriWithRemoteServiceWithVersion){
 // Test Create a uProtocol URI from an empty URI Object.
 TEST(LongUriSerializerTest, BuildProtocolUriFromUriWhenUriIsEmpty) {
     auto uUri = UUri::empty();
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("", uProtocolUri);
 }
 
@@ -489,7 +490,7 @@ TEST(LongUriSerializerTest, BuildProtocolUriFromUriWhenUriIsEmpty) {
 TEST(LongUriSerializerTest, BuildProtocolUriFromUriWhenUriHasEmptyUse) {
     auto use = UEntity::empty();
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/", uProtocolUri);
 }
 
@@ -498,7 +499,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersion) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access/", uProtocolUri);
 }
 
@@ -507,7 +508,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersion) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access/1", uProtocolUri);
 }
 
@@ -517,7 +518,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResource) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access//door", uProtocolUri);
 }
 
@@ -527,7 +528,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResource) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access/1/door", uProtocolUri);
 }
 
@@ -537,7 +538,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access//door.front_left", uProtocolUri);
 }
 
@@ -547,7 +548,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResourceWithInstanceNoMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri( UAuthority::local(), use, UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access/1/door.front_left", uProtocolUri);
 }
 
@@ -557,7 +558,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceNoVersionWithResourceWithInstanceWithMessage) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access//door.front_left#Door", uProtocolUri);
 }
 
@@ -567,7 +568,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasLocalAuthorityServiceAndVersionWithResourceWithInstanceWithMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::local(), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("/body.access/1/door.front_left#Door", uProtocolUri);
 }
 
@@ -576,7 +577,7 @@ TEST(LongUriSerializerTest,
 Build_protocol_uri_from_uri_when_uri_has_remote_authority_service_no_version) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/", uProtocolUri);
 }
 
@@ -586,7 +587,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasRemoteAuthorityNoDeviceWithDomainWithServiceNoVersion) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//my_car_vin/body.access/", uProtocolUri);
 }
 
@@ -596,7 +597,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersion) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::empty());
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/1", uProtocolUri);
 }
 
@@ -606,7 +607,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResource) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
 }
 
@@ -616,7 +617,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResource) {
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access//door", uProtocolUri);
 }
 
@@ -627,7 +628,7 @@ BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResourceWit
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                      UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/1/door.front_left", uProtocolUri);
 }
 
@@ -638,7 +639,7 @@ BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResourceWith
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                     UResource::longFormat("door", "front_left", ""));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access//door.front_left", uProtocolUri);
 }
 
@@ -648,7 +649,7 @@ TEST(LongUriSerializerTest,
 BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceAndVersionWithResourceWithInstanceAndMessage) {
     auto use = UEntity::longFormat("body.access", 1);
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use, UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/1/door.front_left#Door", uProtocolUri);
 }
 
@@ -659,7 +660,7 @@ BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResourceWith
     auto use = UEntity::longFormat("body.access");
     auto uUri = UUri(UAuthority::longRemote("VCU", "MY_CAR_VIN"), use,
                       UResource::longFormat("door", "front_left", "Door"));
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access//door.front_left#Door", uProtocolUri);
 }
 
@@ -668,7 +669,7 @@ BuildProtocolUriFromUriWhenUriHasRemoteAuthorityServiceNoVersionWithResourceWith
 TEST(LongUriSerializerTest, BuildProtocolUriForSourcePartOfRpcRequestWhereSourceIsLocal) {
     UAuthority uAuthority = UAuthority::local();
     auto use = UEntity::longFormat("petapp", 1);
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(UUri::rpcResponse(uAuthority, use));
+    std::string uProtocolUri = LongUriSerializer::serialize(UUri::rpcResponse(uAuthority, use));
     EXPECT_EQ("/petapp/1/rpc.response", uProtocolUri);
 }
 
@@ -677,7 +678,7 @@ TEST(LongUriSerializerTest, BuildProtocolUriForSourcePartOfRpcRequestWhereSource
 TEST(LongUriSerializerTest, BuildProtocolUriForSourcePartOfRpcRequestWhereSourceIsRemote) {
     UAuthority uAuthority = UAuthority::longRemote("bo", "azure");
     auto use = UEntity::longFormat("petapp");
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(UUri::rpcResponse(uAuthority, use));
+    std::string uProtocolUri = LongUriSerializer::serialize(UUri::rpcResponse(uAuthority, use));
     EXPECT_EQ("//bo.azure/petapp//rpc.response", uProtocolUri);
 }
 
@@ -687,7 +688,7 @@ TEST(LongUriSerializerTest, BuildProtocolUriFromPartsWhenTheyAreNull) {
     UEntity uSoftwareEntity;
     UResource uResource;
     auto uUri = UUri(uAuthority, uSoftwareEntity, uResource);
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("", uProtocolUri);
 }
 
@@ -699,7 +700,7 @@ BuildProtocolUriFromUriPartsWhenUriHasRemoteAuthorityServiceAndVersionWithResour
     auto use = UEntity::longFormat("body.access", 1);
     UResource uResource = UResource::longFormat("door");
     auto uUri = UUri(uAuthority, use, uResource);
-    std::string uProtocolUri = LongUriSerializer::getInstance().serialize(uUri);
+    std::string uProtocolUri = LongUriSerializer::serialize(uUri);
     EXPECT_EQ("//vcu.my_car_vin/body.access/1/door", uProtocolUri);
 }
 

--- a/test/uri/serializer/MicroUriSerializerTest.cpp
+++ b/test/uri/serializer/MicroUriSerializerTest.cpp
@@ -277,8 +277,7 @@ TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForIpv6MicroUri) {
     EXPECT_FALSE(uUri.isResolved());
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/test/uri/serializer/MicroUriSerializerTest.cpp
+++ b/test/uri/serializer/MicroUriSerializerTest.cpp
@@ -19,199 +19,183 @@
  * under the License.
  */
 #include <string>
-#include <cgreen/cgreen.h>
+#include <gtest/gtest.h>
 #include "MicroUriSerializer.h"
 #include "UUri.h"
 #include "UAuthority.h"
 #include "UEntity.h"
 #include "UResource.h"
-#include "IpAddress.h"
 
-using namespace cgreen;
 using namespace uprotocol::uri;
 
-#define assertTrue(a) assert_true(a)
-#define assertEquals(a, b) assert_true(b == a)
-#define assertFalse(a) assert_false(a)
-
-Describe(MicroUriSerializer);
-
-BeforeEach(MicroUriSerializer) {
-    // Dummy
-}
-
-AfterEach(MicroUriSerializer) {
-    // Dummy
-}
-
 // Test serialize and deserialize empty content.
-static void testEmptyUri() {
+TEST(MicroUriSerializerTest, EmptyUri) {
     auto uURi = UUri::empty();
-    auto uri = MicroUriSerializer::serialize(uURi);
-    assertTrue(uri.empty());
-    auto uUri2 = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri2.isEmpty());
+    auto uri = MicroUriSerializer::getInstance().serialize(uURi);
+    EXPECT_TRUE(uri.empty());
+    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri2.isEmpty());
 }
 
 // Test happy path Byte serialization of local UUri.
-static void testSerializeUri() {
+TEST(MicroUriSerializerTest, SerializeUri) {
     UAuthority uAuthority = UAuthority::local();
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    auto uUri2 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri, uUri2);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri, uUri2);
 }
 
 // Test happy path with null version.
-static void testSerializeUriWithoutVersion() {
+TEST(MicroUriSerializerTest, SerializeUriWithoutVersion) {
     UAuthority uAuthority = UAuthority::local();
     UEntity uEntity = UEntity::microFormat(2, std::nullopt);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    auto uUri2 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri, uUri2);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri, uUri2);
 }
 
 // Test Serialize a remote UUri to micro without the address.
-static void testSerializeRemoteUriWithoutAddress() {
+TEST(MicroUriSerializerTest, SerializeRemoteUriWithoutAddress) {
     UAuthority uAuthority = UAuthority::longRemote("vcu", "vin");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    assertEquals(uri.size(), 0);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ(uri.size(), 0);
 }
 
 // Test serialize invalid UUris.
-static void testSerializeInvalidUris() {
+TEST(MicroUriSerializerTest, SerializeInvalidUris) {
     auto uUri = UUri(UAuthority::local(), UEntity::microFormat(1, std::nullopt), UResource::empty());
-    auto uri = MicroUriSerializer::serialize(uUri);
-    assertEquals(uri.size(), 0);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ(uri.size(), 0);
 
     auto uUri2 = UUri(UAuthority::local(), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri2 = MicroUriSerializer::serialize(uUri2);
-    assertEquals(uri2.size(), 0);
+    auto uri2 = MicroUriSerializer::getInstance().serialize(uUri2);
+    EXPECT_EQ(uri2.size(), 0);
 
     auto uUri3 = UUri(UAuthority::longRemote("null", "null"), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri3 = MicroUriSerializer::serialize(uUri3);
-    assertEquals(uri3.size(), 0);
+    auto uri3 = MicroUriSerializer::getInstance().serialize(uUri3);
+    EXPECT_EQ(uri3.size(), 0);
 
     auto uUri4 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri4 = MicroUriSerializer::serialize(uUri4);
-    assertEquals(uri4.size(), 0);
+    auto uri4 = MicroUriSerializer::getInstance().serialize(uUri4);
+    EXPECT_EQ(uri4.size(), 0);
 }
 
 // Test serialize uri with invalid ip address type.
-static void testSerializeWithInvalidIpAddressType() {
+TEST(MicroUriSerializerTest, SerializeWithInvalidIpAddressType) {
     UAuthority uAuthority = UAuthority::microRemote("1234567890");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    assertEquals(uri.size(), 0);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ(uri.size(), 0);
 }
 
 // Test serialize uri with invalid IPv4 address.
-static void testSerializeWithInvalidIpv4Address() {
+TEST(MicroUriSerializerTest, SerializeWithInvalidIpv4Address) {
     UAuthority uAuthority = UAuthority::microRemote("123.456.789.0");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    assertEquals(uri.size(), 0);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ(uri.size(), 0);
 }
 
 // Test serialize uri with invalid IPv6 address.
-static void testSerializeWithInvalidIpv6Address() {
+TEST(MicroUriSerializerTest, SerializeWithInvalidIpv6Address) {
     UAuthority uAuthority = UAuthority::microRemote("1234:5678:90ab:cdef:1234");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    assertEquals(uri.size(), 0);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    EXPECT_EQ(uri.size(), 0);
 }
 
 // Test serialize and deserialize IPv4 UUris.
-static void testSerializeIpv4Uri() {
+TEST(MicroUriSerializerTest, SerializeIpv4Uri) {
     UAuthority uAuthority = UAuthority::microRemote("192.168.1.100");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    auto uUri2 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri, uUri2);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri, uUri2);
 
     uAuthority = UAuthority::microRemote("0.0.0.01");
     auto uUri3 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::serialize(uUri3);
-    auto uUri4 = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri4.isEmpty());
+    uri = MicroUriSerializer::getInstance().serialize(uUri3);
+    auto uUri4 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri4.isEmpty());
 }
 
 // Test serialize and deserialize IPv6 UUris.
-static void testSerializeIpv6Uri() {
+TEST(MicroUriSerializerTest, SerializeIpv6Uri) {
     UAuthority uAuthority = UAuthority::microRemote("2001:DB8:85a3:0:0:8a2e:370:7334");
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::serialize(uUri);
-    auto uUri2 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri, uUri2);
+    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri, uUri2);
 
     uAuthority = UAuthority::microRemote("2001:db8:85a3::8a2e:370:7334");
     auto uUri3 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::serialize(uUri);
-    auto uUri4 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri3, uUri4);
+    uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri4 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri3, uUri4);
 
     uAuthority = UAuthority::microRemote("2001:db8:85a3:0:0:8a2e:370:7334");
     auto uUri5 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::serialize(uUri);
-    auto uUri6 = MicroUriSerializer::deserialize(uri);
-    assertEquals(uUri5, uUri6);
+    uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uUri6 = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_EQ(uUri5, uUri6);
 }
 
 // Test deserialize with valid local micro uri.
-static void testDeserializeWithValidLocalUri() {
+TEST(MicroUriSerializerTest, DeserializeWithValidLocalUri) {
     std::vector<uint8_t> uri{0x1, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertFalse(uUri.isEmpty());
-    assertTrue(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
-    assertFalse(uUri.isLongForm());
-    assertTrue(uUri.getUAuthority().isLocal());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(uUri.getUEntity().getVersion().value(), 1);
-    assertTrue(uUri.getUEntity().getId().has_value());
-    assertEquals(uUri.getUEntity().getId().value(), 2);
-    assertTrue(uUri.getUResource().getId().has_value());
-    assertEquals(uUri.getUResource().getId().value(), 5);
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.isEmpty());
+    EXPECT_TRUE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
+    EXPECT_FALSE(uUri.isLongForm());
+    EXPECT_TRUE(uUri.getUAuthority().isLocal());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(uUri.getUEntity().getVersion().value(), 1);
+    EXPECT_TRUE(uUri.getUEntity().getId().has_value());
+    EXPECT_EQ(uUri.getUEntity().getId().value(), 2);
+    EXPECT_TRUE(uUri.getUResource().getId().has_value());
+    EXPECT_EQ(uUri.getUResource().getId().value(), 5);
 }
 
 // Test deserialize with valid IPv4 micro uri.
-static void testDeserializeWithValidIpv4Uri() {
+TEST(MicroUriSerializerTest, DeserializeWithValidIpv4Uri) {
     std::vector<uint8_t> uri = {0x1, 0x1, 0x0, 0x5, 192, 168, 1, 100, 0x0, 0x2, 0x1, 0x0};
-    auto uUri = MicroUriSerializer::deserialize(uri);
-    assertFalse(uUri.isEmpty());
-    assertTrue(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
-    assertFalse(uUri.isLongForm());
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(uUri.getUEntity().getVersion(), 1);
-    assertTrue(uUri.getUEntity().getId().has_value());
-    assertEquals(uUri.getUEntity().getId(), 2);
-    assertTrue(uUri.getUResource().getId().has_value());
-    assertEquals(uUri.getUResource().getId(), 5);
-    assertFalse(uUri.getUAuthority().getAddress().empty());
-    assertEquals(uUri.getUAuthority().getAddress(), "192.168.1.100");
+    auto uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.isEmpty());
+    EXPECT_TRUE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
+    EXPECT_FALSE(uUri.isLongForm());
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(uUri.getUEntity().getVersion(), 1);
+    EXPECT_TRUE(uUri.getUEntity().getId().has_value());
+    EXPECT_EQ(uUri.getUEntity().getId(), 2);
+    EXPECT_TRUE(uUri.getUResource().getId().has_value());
+    EXPECT_EQ(uUri.getUResource().getId(), 5);
+    EXPECT_FALSE(uUri.getUAuthority().getAddress().empty());
+    EXPECT_EQ(uUri.getUAuthority().getAddress(), "192.168.1.100");
 }
 
 // Test deserialize with valid IPv6 micro uri.
-static void testDeserializeWithValidIpv6Uri() {
+TEST(MicroUriSerializerTest, DeserializeWithValidIpv6Uri) {
     std::string ipv6 = "2001:db8:85a3::8a2e:370:7334";
     IpAddress ipAddress(ipv6);
     std::vector<uint8_t> ipv6Bytes = ipAddress.getBytes();
@@ -223,60 +207,60 @@ static void testDeserializeWithValidIpv6Uri() {
     uri.insert(uri.end(), ipv6Bytes.begin(), ipv6Bytes.end());
     uri.insert(uri.end(), footer.begin(), footer.end());
 
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertFalse(uUri.isEmpty());
-    assertTrue(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
-    assertFalse(uUri.isLongForm());
-    assertTrue(uUri.getUAuthority().isRemote());
-    assertTrue(uUri.getUEntity().getVersion().has_value());
-    assertEquals(uUri.getUEntity().getVersion(), 1);
-    assertTrue(uUri.getUEntity().getId().has_value());
-    assertEquals(uUri.getUEntity().getId(), 2);
-    assertTrue(uUri.getUResource().getId().has_value());
-    assertEquals(uUri.getUResource().getId(), 5);
-    assertFalse(uUri.getUAuthority().getAddress().empty());
-    assertEquals(uUri.getUAuthority().getAddress(), ipv6);
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_FALSE(uUri.isEmpty());
+    EXPECT_TRUE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
+    EXPECT_FALSE(uUri.isLongForm());
+    EXPECT_TRUE(uUri.getUAuthority().isRemote());
+    EXPECT_TRUE(uUri.getUEntity().getVersion().has_value());
+    EXPECT_EQ(uUri.getUEntity().getVersion(), 1);
+    EXPECT_TRUE(uUri.getUEntity().getId().has_value());
+    EXPECT_EQ(uUri.getUEntity().getId(), 2);
+    EXPECT_TRUE(uUri.getUResource().getId().has_value());
+    EXPECT_EQ(uUri.getUResource().getId(), 5);
+    EXPECT_FALSE(uUri.getUAuthority().getAddress().empty());
+    EXPECT_EQ(uUri.getUAuthority().getAddress(), ipv6);
 }
 
 // Test deserialize with invalid version.
-static void testDeserializeWithInvalidVersion() {
+TEST(MicroUriSerializerTest, DeserializeWithInvalidVersion) {
     std::vector<uint8_t> uri = {0x9, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
 }
 
 // Test deserialize with invalid type.
-static void testDeserializeWithInvalidType() {
+TEST(MicroUriSerializerTest, DeserializeWithInvalidType) {
     std::vector<uint8_t> uri = {0x1, 0x9, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
 }
 
 // Test deserialize with wrong size for local micro URI.
-static void testDeserializeWithWrongSizeForLocalMicroUri() {
+TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForLocalMicroUri) {
     std::vector<uint8_t> uri = {0x1, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0, 0x0};
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
 }
 
 // Test deserialize with wrong size for IPv4 micro URI.
-static void testDeserializeWithWrongSizeForIpv4MicroUri() {
+TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForIpv4MicroUri) {
     std::vector<uint8_t> uri = {0x1, 0x1, 0x0, 0x5, 192, 168, 1, 100, 0x0, 0x2, 0x1, 0x0, 0x0};
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
 }
 
 // Test deserialize with wrong size for IPv6 micro URI.
-static void testDeserializeWithWrongSizeForIpv6MicroUri() {
+TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForIpv6MicroUri) {
     std::vector<uint8_t> ipv6Bytes(30, 0);
     std::vector<uint8_t> header = {0x1, 0x2, 0x0, 0x5};
     std::vector<uint8_t> footer = {0x0, 0x2, 0x1, 0x0};
@@ -286,38 +270,14 @@ static void testDeserializeWithWrongSizeForIpv6MicroUri() {
     uri.insert(uri.end(), ipv6Bytes.begin(), ipv6Bytes.end());
     uri.insert(uri.end(), footer.begin(), footer.end());
 
-    UUri uUri = MicroUriSerializer::deserialize(uri);
-    assertTrue(uUri.isEmpty());
-    assertFalse(uUri.isMicroForm());
-    assertFalse(uUri.isResolved());
+    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    EXPECT_TRUE(uUri.isEmpty());
+    EXPECT_FALSE(uUri.isMicroForm());
+    EXPECT_FALSE(uUri.isResolved());
 }
 
-Ensure(MicroUriSerializer, all_tests) {
-    testEmptyUri();
-    testSerializeUri();
-    testSerializeUriWithoutVersion();
-    testSerializeRemoteUriWithoutAddress();
-    testSerializeInvalidUris();
-    testSerializeWithInvalidIpAddressType();
-    testSerializeWithInvalidIpv4Address();
-    testSerializeWithInvalidIpv6Address();
-    testSerializeIpv4Uri();
-    testSerializeIpv6Uri();
-    testDeserializeWithValidLocalUri();
-    testDeserializeWithValidIpv4Uri();
-    testDeserializeWithValidIpv6Uri();
-    testDeserializeWithInvalidVersion();
-    testDeserializeWithInvalidType();
-    testDeserializeWithWrongSizeForLocalMicroUri();
-    testDeserializeWithWrongSizeForIpv4MicroUri();
-    testDeserializeWithWrongSizeForIpv6MicroUri();
-}
-
-
-int main(int argc, const char** argv) {
-    TestSuite* suite = create_test_suite();
-
-    add_test_with_context(suite, MicroUriSerializer, all_tests);
-
-    return run_test_suite(suite, create_text_reporter());
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/uri/serializer/MicroUriSerializerTest.cpp
+++ b/test/uri/serializer/MicroUriSerializerTest.cpp
@@ -25,15 +25,16 @@
 #include "UAuthority.h"
 #include "UEntity.h"
 #include "UResource.h"
+#include "IpAddress.h"
 
 using namespace uprotocol::uri;
 
 // Test serialize and deserialize empty content.
 TEST(MicroUriSerializerTest, EmptyUri) {
     auto uURi = UUri::empty();
-    auto uri = MicroUriSerializer::getInstance().serialize(uURi);
+    auto uri = MicroUriSerializer::serialize(uURi);
     EXPECT_TRUE(uri.empty());
-    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uUri2 = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri2.isEmpty());
 }
 
@@ -43,8 +44,8 @@ TEST(MicroUriSerializerTest, SerializeUri) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uri = MicroUriSerializer::serialize(uUri);
+    auto uUri2 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri, uUri2);
 }
 
@@ -54,8 +55,8 @@ TEST(MicroUriSerializerTest, SerializeUriWithoutVersion) {
     UEntity uEntity = UEntity::microFormat(2, std::nullopt);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uri = MicroUriSerializer::serialize(uUri);
+    auto uUri2 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri, uUri2);
 }
 
@@ -65,26 +66,26 @@ TEST(MicroUriSerializerTest, SerializeRemoteUriWithoutAddress) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uri = MicroUriSerializer::serialize(uUri);
     EXPECT_EQ(uri.size(), 0);
 }
 
 // Test serialize invalid UUris.
 TEST(MicroUriSerializerTest, SerializeInvalidUris) {
     auto uUri = UUri(UAuthority::local(), UEntity::microFormat(1, std::nullopt), UResource::empty());
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uri = MicroUriSerializer::serialize(uUri);
     EXPECT_EQ(uri.size(), 0);
 
     auto uUri2 = UUri(UAuthority::local(), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri2 = MicroUriSerializer::getInstance().serialize(uUri2);
+    auto uri2 = MicroUriSerializer::serialize(uUri2);
     EXPECT_EQ(uri2.size(), 0);
 
     auto uUri3 = UUri(UAuthority::longRemote("null", "null"), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri3 = MicroUriSerializer::getInstance().serialize(uUri3);
+    auto uri3 = MicroUriSerializer::serialize(uUri3);
     EXPECT_EQ(uri3.size(), 0);
 
     auto uUri4 = UUri(UAuthority::resolvedRemote("vcu", "vin", ""), UEntity::longFormat("", std::nullopt), UResource::forRpcRequest("", 1));
-    auto uri4 = MicroUriSerializer::getInstance().serialize(uUri4);
+    auto uri4 = MicroUriSerializer::serialize(uUri4);
     EXPECT_EQ(uri4.size(), 0);
 }
 
@@ -94,7 +95,7 @@ TEST(MicroUriSerializerTest, SerializeWithInvalidIpAddressType) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uri = MicroUriSerializer::serialize(uUri);
     EXPECT_EQ(uri.size(), 0);
 }
 
@@ -104,7 +105,7 @@ TEST(MicroUriSerializerTest, SerializeWithInvalidIpv4Address) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uri = MicroUriSerializer::serialize(uUri);
     EXPECT_EQ(uri.size(), 0);
 }
 
@@ -114,7 +115,7 @@ TEST(MicroUriSerializerTest, SerializeWithInvalidIpv6Address) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
+    auto uri = MicroUriSerializer::serialize(uUri);
     EXPECT_EQ(uri.size(), 0);
 }
 
@@ -124,14 +125,14 @@ TEST(MicroUriSerializerTest, SerializeIpv4Uri) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uri = MicroUriSerializer::serialize(uUri);
+    auto uUri2 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri, uUri2);
 
     uAuthority = UAuthority::microRemote("0.0.0.01");
     auto uUri3 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::getInstance().serialize(uUri3);
-    auto uUri4 = MicroUriSerializer::getInstance().deserialize(uri);
+    uri = MicroUriSerializer::serialize(uUri3);
+    auto uUri4 = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri4.isEmpty());
 }
 
@@ -141,27 +142,27 @@ TEST(MicroUriSerializerTest, SerializeIpv6Uri) {
     UEntity uEntity = UEntity::microFormat(2, 1);
     UResource uResource = UResource::microFormat(3);
     auto uUri = UUri(uAuthority, uEntity, uResource);
-    auto uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri2 = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uri = MicroUriSerializer::serialize(uUri);
+    auto uUri2 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri, uUri2);
 
     uAuthority = UAuthority::microRemote("2001:db8:85a3::8a2e:370:7334");
     auto uUri3 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri4 = MicroUriSerializer::getInstance().deserialize(uri);
+    uri = MicroUriSerializer::serialize(uUri);
+    auto uUri4 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri3, uUri4);
 
     uAuthority = UAuthority::microRemote("2001:db8:85a3:0:0:8a2e:370:7334");
     auto uUri5 = UUri(uAuthority, uEntity, uResource);
-    uri = MicroUriSerializer::getInstance().serialize(uUri);
-    auto uUri6 = MicroUriSerializer::getInstance().deserialize(uri);
+    uri = MicroUriSerializer::serialize(uUri);
+    auto uUri6 = MicroUriSerializer::deserialize(uri);
     EXPECT_EQ(uUri5, uUri6);
 }
 
 // Test deserialize with valid local micro uri.
 TEST(MicroUriSerializerTest, DeserializeWithValidLocalUri) {
     std::vector<uint8_t> uri{0x1, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.isEmpty());
     EXPECT_TRUE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -178,7 +179,7 @@ TEST(MicroUriSerializerTest, DeserializeWithValidLocalUri) {
 // Test deserialize with valid IPv4 micro uri.
 TEST(MicroUriSerializerTest, DeserializeWithValidIpv4Uri) {
     std::vector<uint8_t> uri = {0x1, 0x1, 0x0, 0x5, 192, 168, 1, 100, 0x0, 0x2, 0x1, 0x0};
-    auto uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    auto uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.isEmpty());
     EXPECT_TRUE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -207,7 +208,7 @@ TEST(MicroUriSerializerTest, DeserializeWithValidIpv6Uri) {
     uri.insert(uri.end(), ipv6Bytes.begin(), ipv6Bytes.end());
     uri.insert(uri.end(), footer.begin(), footer.end());
 
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_FALSE(uUri.isEmpty());
     EXPECT_TRUE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -226,7 +227,7 @@ TEST(MicroUriSerializerTest, DeserializeWithValidIpv6Uri) {
 // Test deserialize with invalid version.
 TEST(MicroUriSerializerTest, DeserializeWithInvalidVersion) {
     std::vector<uint8_t> uri = {0x9, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -235,7 +236,7 @@ TEST(MicroUriSerializerTest, DeserializeWithInvalidVersion) {
 // Test deserialize with invalid type.
 TEST(MicroUriSerializerTest, DeserializeWithInvalidType) {
     std::vector<uint8_t> uri = {0x1, 0x9, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0};
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -244,7 +245,7 @@ TEST(MicroUriSerializerTest, DeserializeWithInvalidType) {
 // Test deserialize with wrong size for local micro URI.
 TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForLocalMicroUri) {
     std::vector<uint8_t> uri = {0x1, 0x0, 0x0, 0x5, 0x0, 0x2, 0x1, 0x0, 0x0};
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -253,7 +254,7 @@ TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForLocalMicroUri) {
 // Test deserialize with wrong size for IPv4 micro URI.
 TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForIpv4MicroUri) {
     std::vector<uint8_t> uri = {0x1, 0x1, 0x0, 0x5, 192, 168, 1, 100, 0x0, 0x2, 0x1, 0x0, 0x0};
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());
@@ -270,7 +271,7 @@ TEST(MicroUriSerializerTest, DeserializeWithWrongSizeForIpv6MicroUri) {
     uri.insert(uri.end(), ipv6Bytes.begin(), ipv6Bytes.end());
     uri.insert(uri.end(), footer.begin(), footer.end());
 
-    UUri uUri = MicroUriSerializer::getInstance().deserialize(uri);
+    UUri uUri = MicroUriSerializer::deserialize(uri);
     EXPECT_TRUE(uUri.isEmpty());
     EXPECT_FALSE(uUri.isMicroForm());
     EXPECT_FALSE(uUri.isResolved());

--- a/test/uuid/uuid_test.cpp
+++ b/test/uuid/uuid_test.cpp
@@ -8,60 +8,55 @@ using namespace uprotocol::uuid;
 using namespace uprotocol::v1;
 
 //UUID create, serilize and deserialize
-TEST(UUIDTest, Class)
-{
+TEST(UUIDTest, Class) {
     UUID uuId = Uuidv8Factory::create();
-    std::vector<uint8_t> vectUuid = UuidSerializer::instance().serializeToBytes(uuId);
-    UUID uuIdFromByteArr = UuidSerializer::instance().deserializeFromBytes(vectUuid);
-    EXPECT_TRUE(UuidSerializer::instance().getTime(uuId) == UuidSerializer::instance().getTime(uuIdFromByteArr));
-    EXPECT_TRUE(UuidSerializer::instance().getCount(uuId) == UuidSerializer::instance().getCount(uuIdFromByteArr));
+    std::vector<uint8_t> vectUuid = UuidSerializer::serializeToBytes(uuId);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vectUuid);
+    EXPECT_TRUE(UuidSerializer::getTime(uuId) == UuidSerializer::getTime(uuIdFromByteArr));
+    EXPECT_TRUE(UuidSerializer::getCount(uuId) == UuidSerializer::getCount(uuIdFromByteArr));
 
     std::string str = "0080b636-8303-8701-8ebe-7a9a9e767a9f";
-    UUID uuIdNew = UuidSerializer::instance().deserializeFromString(str);
-    EXPECT_EQ(UuidSerializer::instance().serializeToString(uuIdNew), str);
+    UUID uuIdNew = UuidSerializer::deserializeFromString(str);
+    EXPECT_EQ(UuidSerializer::serializeToString(uuIdNew), str);
 }
 
 //Negative test - serialize and deserialize
-TEST(UUIDTest, NegStringConstructor)
-{
+TEST(UUIDTest, NegStringConstructor) {
     std::string str = "0080b636-8303-8701-8ebe-7a9a9e767a9f";
-    UUID uuIdNew = UuidSerializer::instance().deserializeFromString(str);
+    UUID uuIdNew = UuidSerializer::deserializeFromString(str);
     str = "test" +str;
-    EXPECT_NE(UuidSerializer::instance().serializeToString(uuIdNew), str);
+    EXPECT_NE(UuidSerializer::serializeToString(uuIdNew), str);
 }
 
 //Negative test - empty string
-TEST(UUIDTest, NegEmptyString)
-{
+TEST(UUIDTest, NegEmptyString) {
     //Empty String
     std::string str = "";
-    UUID uuId = UuidSerializer::instance().deserializeFromString(str);
-    EXPECT_NE(UuidSerializer::instance().serializeToString(uuId), str);
-    EXPECT_EQ(UuidSerializer::instance().getCount(uuId), uint64_t(0));
+    UUID uuId = UuidSerializer::deserializeFromString(str);
+    EXPECT_NE(UuidSerializer::serializeToString(uuId), str);
+    EXPECT_EQ(UuidSerializer::getCount(uuId), uint64_t(0));
 }
 
 //Negative test - deserializeFromString - Invalid String with more than 32 hex characters
 TEST(UUIDTest, NegStringWithMoreThan32HexCharsTest)
 {
     std::string str = "0080b636-8303-8701-8ebe-7a9a9e767a9f-1abc";
-    UUID uuId = UuidSerializer::instance().deserializeFromString(str);
-    EXPECT_NE(UuidSerializer::instance().serializeToString(uuId), str);
-    EXPECT_EQ(UuidSerializer::instance().getCount(uuId), uint64_t(0));
+    UUID uuId = UuidSerializer::deserializeFromString(str);
+    EXPECT_NE(UuidSerializer::serializeToString(uuId), str);
+    EXPECT_EQ(UuidSerializer::getCount(uuId), uint64_t(0));
 }
 
 //Negative test deserializeFromBytes - Empty Byte vector
-TEST(UUIDTest, NegEmptyByteVector)
-{
+TEST(UUIDTest, NegEmptyByteVector) {
     std::vector<uint8_t> vectEmpty;
-    UUID uuIdFromByteArr = UuidSerializer::instance().deserializeFromBytes(vectEmpty);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vectEmpty);
     uint64_t val(0);
 
-    EXPECT_EQ(UuidSerializer::instance().getCount(uuIdFromByteArr), val);
+    EXPECT_EQ(UuidSerializer::getCount(uuIdFromByteArr), val);
 }
 
 //Negative test  deserializeFromBytes - Greater than 16
-TEST(UUIDTest, NegGreaterThanDefinedSize)
-{
+TEST(UUIDTest, NegGreaterThanDefinedSize) {
     std::vector<uint8_t> vect(18);
     uint64_t msb(1);
     uint64_t lsb(1);
@@ -70,15 +65,14 @@ TEST(UUIDTest, NegGreaterThanDefinedSize)
         vect[i + 8] = lsb;
     }
 
-    UUID uuIdFromByteArr = UuidSerializer::instance().deserializeFromBytes(vect);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vect);
     uint64_t val(0);
 
-    EXPECT_EQ(UuidSerializer::instance().getCount(uuIdFromByteArr), val);
+    EXPECT_EQ(UuidSerializer::getCount(uuIdFromByteArr), val);
 }
 
 //Negative test deserializeFromBytes - Invalid Byte vector
-TEST(UUIDTest, NegInvalidByteVector)
-{
+TEST(UUIDTest, NegInvalidByteVector) {
     std::vector<uint8_t> vect(16);
     uint64_t msb(1);
     uint64_t lsb(1);
@@ -86,16 +80,15 @@ TEST(UUIDTest, NegInvalidByteVector)
         vect[i] = msb ;
         vect[i + 8] = lsb;
     }
-    UUID uuIdFromByteArr = UuidSerializer::instance().deserializeFromBytes(vect);
+    UUID uuIdFromByteArr = UuidSerializer::deserializeFromBytes(vect);
     uint64_t val(1);
     std::string str = "";
 
-    EXPECT_NE(UuidSerializer::instance().serializeToString(uuIdFromByteArr), str);
-    EXPECT_NE(UuidSerializer::instance().getCount(uuIdFromByteArr), val);
+    EXPECT_NE(UuidSerializer::serializeToString(uuIdFromByteArr), str);
+    EXPECT_NE(UuidSerializer::getCount(uuIdFromByteArr), val);
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Refactored URI unit tests to google unit tests framework.
Updated CMake to include gtest library for linking.
Ran unit tests and all of them are passing. 


